### PR TITLE
fix(flex): fix warning "export FlexState was not found"

### DIFF
--- a/src/app/pages/navigator/navigator.component.ts
+++ b/src/app/pages/navigator/navigator.component.ts
@@ -7,7 +7,7 @@ import { Media } from '../../core/media.service';
 import { Tool } from '../../tool/shared/tool.interface';
 import { SearchResult } from '../../search/shared/search-result.interface';
 import { ContextService } from '../../core/context.service';
-import { FlexState } from '../../shared/flex/flex.component';
+import { FlexState } from '../../shared/flex';
 
 import { AppStore } from '../../app.store';
 

--- a/src/app/shared/collapsible/collapsible.component.ts
+++ b/src/app/shared/collapsible/collapsible.component.ts
@@ -1,6 +1,6 @@
 import { Component, Input, ViewChild } from '@angular/core';
 
-import { FlexState, FlexComponent } from '../flex/flex.component';
+import { FlexState, FlexComponent } from '../flex';
 
 @Component({
   selector: 'igo-collapsible',

--- a/src/app/shared/flex/flex.component.ts
+++ b/src/app/shared/flex/flex.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit, Input, ViewChild, ElementRef } from '@angular/core';
-import { FlexState, FlexDirection} from "./flex";
+import { FlexState, FlexDirection} from './flex';
 
 
 @Component({

--- a/src/app/shared/flex/flex.component.ts
+++ b/src/app/shared/flex/flex.component.ts
@@ -1,10 +1,6 @@
 import { Component, OnInit, Input, ViewChild, ElementRef } from '@angular/core';
+import { FlexState, FlexDirection} from "./flex";
 
-export type FlexState =
-  'initial' | 'collapsed' | 'expanded' | 'transition';
-
-export type FlexDirection =
-  'column' | 'row';
 
 @Component({
   selector: 'igo-flex',

--- a/src/app/shared/flex/flex.ts
+++ b/src/app/shared/flex/flex.ts
@@ -1,0 +1,5 @@
+export type FlexState =
+  'initial' | 'collapsed' | 'expanded' | 'transition';
+
+export type FlexDirection =
+  'column' | 'row';

--- a/src/app/shared/flex/index.ts
+++ b/src/app/shared/flex/index.ts
@@ -1,0 +1,2 @@
+export * from './flex';
+export * from './flex.component';


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines:https://github.com/infra-geo-ouverte/igo2/blob/master/.github/CONTRIBUTING.md#git-commit-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What is the current behavior?** (You can also link to an open issue here)

WARNING in ./src/app/shared/collapsible/collapsible.component.ts
32:79-88 "export 'FlexState' was not found in '../flex/flex.component'


**What is the new behavior?**

No warning. See this issue for more details: https://github.com/angular/angular-cli/issues/2034

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[X] No
```