### PR TITLE
chore(lint): move no unused locals tslint to ts compiler

### DIFF
--- a/e2e/app.e2e-spec.ts
+++ b/e2e/app.e2e-spec.ts
@@ -1,5 +1,3 @@
-/* tslint:disable:no-unused-variable */
-import { browser, element, by } from 'protractor';
 import { IgoPage } from './app.po';
 import {} from 'jasmine';
 

--- a/e2e/tsconfig.json
+++ b/e2e/tsconfig.json
@@ -4,6 +4,7 @@
     "declaration": false,
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
+    "noUnusedLocals": true,
     "module": "commonjs",
     "moduleResolution": "node",
     "outDir": "../dist/out-tsc-e2e",

--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -1,4 +1,3 @@
-/* tslint:disable:no-unused-variable */
 import { TestBed, async } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
 

--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -33,9 +33,4 @@ describe('AppComponent', () => {
     expect(app).toBeTruthy();
   }));
 
-  it(`should have as title 'igo works!'`, async(() => {
-    const fixture = TestBed.createComponent(AppComponent);
-    const app = fixture.debugElement.componentInstance;
-    expect(app.title).toEqual('igo works!');
-  }));
 });

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,7 +1,5 @@
 import { Component } from '@angular/core';
 
-import { MediaService } from './core/media.service';
-
 @Component({
   selector: 'igo-app',
   templateUrl: './app.component.html',
@@ -10,5 +8,5 @@ import { MediaService } from './core/media.service';
 export class AppComponent {
   title = 'igo works!';
 
-  constructor (private mediaService: MediaService) { }
+  constructor () { }
 }

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,4 +1,5 @@
 import { Component } from '@angular/core';
+import { MediaService } from './core/media.service';
 
 @Component({
   selector: 'igo-app',
@@ -6,7 +7,6 @@ import { Component } from '@angular/core';
   styleUrls: ['./app.component.styl']
 })
 export class AppComponent {
-  title = 'igo works!';
-
-  constructor () { }
+  constructor (protected mediaService: MediaService) {
+  }
 }

--- a/src/app/core/context.service.spec.ts
+++ b/src/app/core/context.service.spec.ts
@@ -1,6 +1,4 @@
-/* tslint:disable:no-unused-variable */
-
-import { TestBed, async, inject } from '@angular/core/testing';
+import { TestBed, inject } from '@angular/core/testing';
 import { ContextService } from './context.service';
 
 import { ToolService } from './tool.service';

--- a/src/app/core/map.service.spec.ts
+++ b/src/app/core/map.service.spec.ts
@@ -1,5 +1,4 @@
-/* tslint:disable:no-unused-variable */
-import { TestBed, async, inject } from '@angular/core/testing';
+import { TestBed, inject } from '@angular/core/testing';
 import { MapService } from './map.service';
 
 import { provideAppStore } from './core.module';

--- a/src/app/core/media.service.spec.ts
+++ b/src/app/core/media.service.spec.ts
@@ -1,5 +1,4 @@
-/* tslint:disable:no-unused-variable */
-import { TestBed, async, inject } from '@angular/core/testing';
+import { TestBed, inject } from '@angular/core/testing';
 import { MediaService } from './media.service';
 import { provideAppStore } from './core.module';
 

--- a/src/app/core/search-source.service.spec.ts
+++ b/src/app/core/search-source.service.spec.ts
@@ -1,5 +1,4 @@
-/* tslint:disable:no-unused-variable */
-import { TestBed, async, inject } from '@angular/core/testing';
+import { TestBed, inject } from '@angular/core/testing';
 import { HttpModule, JsonpModule } from '@angular/http';
 import { SearchSourceService } from './search-source.service';
 

--- a/src/app/core/search.service.spec.ts
+++ b/src/app/core/search.service.spec.ts
@@ -1,9 +1,7 @@
-/* tslint:disable:no-unused-variable */
-import { TestBed, async, inject } from '@angular/core/testing';
+import { TestBed, inject } from '@angular/core/testing';
 import { SearchService } from './search.service';
 import { HttpModule, JsonpModule } from '@angular/http';
 
-import { searchResults } from '../reducers';
 import {
    provideAppStore,
    provideSearchSource,

--- a/src/app/core/search.service.ts
+++ b/src/app/core/search.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { Http, Response } from '@angular/http';
+import { Response } from '@angular/http';
 import { Store } from '@ngrx/store';
 
 import { Observable } from 'rxjs/Observable';
@@ -16,8 +16,7 @@ export class SearchService {
 
   subscriptions: Subscription[] = [];
 
-  constructor(private http: Http,
-              private store: Store<AppStore>,
+  constructor(private store: Store<AppStore>,
               private searchSourceService: SearchSourceService) {
   }
 

--- a/src/app/core/tool.service.spec.ts
+++ b/src/app/core/tool.service.spec.ts
@@ -1,6 +1,4 @@
-/* tslint:disable:no-unused-variable */
-
-import { TestBed, async, inject } from '@angular/core/testing';
+import { TestBed, inject } from '@angular/core/testing';
 import { ToolService } from './tool.service';
 
 describe('ToolService', () => {

--- a/src/app/language/language.component.spec.ts
+++ b/src/app/language/language.component.spec.ts
@@ -1,7 +1,4 @@
-/* tslint:disable:no-unused-variable */
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
-import { By } from '@angular/platform-browser';
-import { DebugElement } from '@angular/core';
 
 import { LanguageComponent } from './language.component';
 

--- a/src/app/map/map.component.spec.ts
+++ b/src/app/map/map.component.spec.ts
@@ -1,4 +1,3 @@
-/* tslint:disable:no-unused-variable */
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { DebugElement } from '@angular/core';

--- a/src/app/map/shared/layer.service.spec.ts
+++ b/src/app/map/shared/layer.service.spec.ts
@@ -1,6 +1,4 @@
-/* tslint:disable:no-unused-variable */
-
-import { TestBed, async, inject } from '@angular/core/testing';
+import { TestBed, inject } from '@angular/core/testing';
 import { LayerService } from './layer.service';
 
 describe('LayerService', () => {

--- a/src/app/pages/navigator/navigator.component.spec.ts
+++ b/src/app/pages/navigator/navigator.component.spec.ts
@@ -1,4 +1,4 @@
-/* tslint:disable:no-unused-variable */
+
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { DebugElement } from '@angular/core';

--- a/src/app/search/search-bar/search-bar.component.spec.ts
+++ b/src/app/search/search-bar/search-bar.component.spec.ts
@@ -1,4 +1,4 @@
-/* tslint:disable:no-unused-variable */
+
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { DebugElement } from '@angular/core';

--- a/src/app/search/search-result-details/search-result-details.component.spec.ts
+++ b/src/app/search/search-result-details/search-result-details.component.spec.ts
@@ -1,4 +1,4 @@
-/* tslint:disable:no-unused-variable */
+
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { DebugElement } from '@angular/core';

--- a/src/app/search/search-result/search-result.component.spec.ts
+++ b/src/app/search/search-result/search-result.component.spec.ts
@@ -1,4 +1,4 @@
-/* tslint:disable:no-unused-variable */
+
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { DebugElement } from '@angular/core';

--- a/src/app/search/search-tool/search-tool.component.spec.ts
+++ b/src/app/search/search-tool/search-tool.component.spec.ts
@@ -1,4 +1,4 @@
-/* tslint:disable:no-unused-variable */
+
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { DebugElement } from '@angular/core';

--- a/src/app/shared/backdrop/backdrop.component.spec.ts
+++ b/src/app/shared/backdrop/backdrop.component.spec.ts
@@ -1,4 +1,4 @@
-/* tslint:disable:no-unused-variable */
+
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { DebugElement } from '@angular/core';

--- a/src/app/shared/collapsible/collapsible.component.spec.ts
+++ b/src/app/shared/collapsible/collapsible.component.spec.ts
@@ -1,4 +1,4 @@
-/* tslint:disable:no-unused-variable */
+
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { DebugElement } from '@angular/core';

--- a/src/app/shared/directives/clickout.directive.spec.ts
+++ b/src/app/shared/directives/clickout.directive.spec.ts
@@ -1,4 +1,4 @@
-/* tslint:disable:no-unused-variable */
+
 
 import { TestBed, async } from '@angular/core/testing';
 import { ElementRef } from '@angular/core';

--- a/src/app/shared/flex/flex.component.spec.ts
+++ b/src/app/shared/flex/flex.component.spec.ts
@@ -1,4 +1,3 @@
-/* tslint:disable:no-unused-variable */
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { DebugElement } from '@angular/core';

--- a/src/app/shared/list/list-item.directive.spec.ts
+++ b/src/app/shared/list/list-item.directive.spec.ts
@@ -1,4 +1,4 @@
-/* tslint:disable:no-unused-variable */
+
 
 import { TestBed, async } from '@angular/core/testing';
 import { ElementRef } from '@angular/core';

--- a/src/app/shared/list/list.component.spec.ts
+++ b/src/app/shared/list/list.component.spec.ts
@@ -1,4 +1,4 @@
-/* tslint:disable:no-unused-variable */
+
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { DebugElement } from '@angular/core';

--- a/src/app/shared/panel/panel.component.spec.ts
+++ b/src/app/shared/panel/panel.component.spec.ts
@@ -1,4 +1,4 @@
-/* tslint:disable:no-unused-variable */
+
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { DebugElement } from '@angular/core';

--- a/src/app/shared/pipes/keyvalue.pipe.spec.ts
+++ b/src/app/shared/pipes/keyvalue.pipe.spec.ts
@@ -1,4 +1,4 @@
-/* tslint:disable:no-unused-variable */
+
 
 import { TestBed, async } from '@angular/core/testing';
 import { KeyvaluePipe } from './keyvalue.pipe';

--- a/src/app/shared/sidenav/sidenav.component.spec.ts
+++ b/src/app/shared/sidenav/sidenav.component.spec.ts
@@ -1,4 +1,4 @@
-/* tslint:disable:no-unused-variable */
+
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { DebugElement } from '@angular/core';

--- a/src/app/tool/toolbar-item/toolbar-item.component.spec.ts
+++ b/src/app/tool/toolbar-item/toolbar-item.component.spec.ts
@@ -1,4 +1,3 @@
-/* tslint:disable:no-unused-variable */
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { DebugElement } from '@angular/core';

--- a/src/app/tool/toolbar/toolbar.component.spec.ts
+++ b/src/app/tool/toolbar/toolbar.component.spec.ts
@@ -1,4 +1,3 @@
-/* tslint:disable:no-unused-variable */
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { DebugElement } from '@angular/core';

--- a/src/app/tool/toolbox/toolbox.component.spec.ts
+++ b/src/app/tool/toolbox/toolbox.component.spec.ts
@@ -1,4 +1,3 @@
-/* tslint:disable:no-unused-variable */
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { DebugElement } from '@angular/core';

--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -4,6 +4,7 @@
     "declaration": false,
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
+    "noUnusedLocals": true,
     "lib": ["es6", "dom"],
     "mapRoot": "./",
     "module": "es6",

--- a/tslint.json
+++ b/tslint.json
@@ -53,7 +53,6 @@
     "no-switch-case-fall-through": true,
     "no-trailing-whitespace": true,
     "no-unused-expression": true,
-    "no-unused-variable": true,
     "no-use-before-declare": true,
     "no-var-keyword": true,
     "object-literal-sort-keys": false,


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines:https://github.com/infra-geo-ouverte/igo2/blob/master/.github/CONTRIBUTING.md#git-commit-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What is the current behavior?** (You can also link to an open issue here)

no-unused-variable rule is obsolete in tslint

**What is the new behavior?**

Use new compiler parameter --noUnusedLocals.

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```
