### PR TITLE
fix(sidenav focus on close): Prevent the sidenav from focusing the se…

### DIFF
--- a/src/app/shared/sidenav/sidenav.component.html
+++ b/src/app/shared/sidenav/sidenav.component.html
@@ -1,4 +1,9 @@
-<md-sidenav [opened]="opened" mode="side">
+<md-sidenav
+  mode="side"
+  [opened]="opened"
+  (open)="onOpen()"
+  (close-start)="onCloseStart()"
+  (close)="onClose()">
   <div class="igo-sidenav-content">
   	<ng-content></ng-content>
   </div>

--- a/src/app/shared/sidenav/sidenav.component.ts
+++ b/src/app/shared/sidenav/sidenav.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input } from '@angular/core';
+import { Component, Input, Renderer } from '@angular/core';
 
 @Component({
   selector: 'igo-sidenav',
@@ -9,5 +9,32 @@ export class SidenavComponent {
 
   @Input() opened: boolean = false;
 
-  constructor() { }
+  private focusedElement: HTMLElement;
+  private blurElement: HTMLElement;
+
+  onOpen() {
+    this.focusedElement = document.activeElement as HTMLElement;
+  };
+
+  onCloseStart() {
+    const focusedElement = document.activeElement as HTMLElement;
+    if (focusedElement !== this.focusedElement) {
+      this.blurElement = this.focusedElement;
+    } else {
+      this.blurElement = undefined;
+    }
+  };
+
+  // This is to prevent the sidenav from focusing
+  // the element that was focused before it was opened
+  onClose() {
+    if (this.blurElement) {
+      this.renderer.invokeElementMethod(this.blurElement, 'blur');
+    }
+
+    this.blurElement = undefined;
+    this.focusedElement = undefined;
+  };
+
+  constructor(private renderer: Renderer) { }
 }


### PR DESCRIPTION
…arch bar on close

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines:https://github.com/infra-geo-ouverte/igo2/blob/master/.github/CONTRIBUTING.md#git-commit-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What is the current behavior?** (You can also link to an open issue here)
- The search bar (most of the time) is focused when the sidenav is closed


**What is the new behavior?**
- The focused element is kept focused when the sidenav is closed but no element os focused if none was before the sidenav closes.



**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```