### PR TITLE
feat(tool): Keep tool history and go back functionnality

### DIFF
--- a/src/app/context/context-list-item/context-list-item.component.html
+++ b/src/app/context/context-list-item/context-list-item.component.html
@@ -7,7 +7,7 @@
     (click)="editContext.emit(context)"
     *ngIf="edition"
     [md-tooltip]="'Edit Context' | translate"
-    tooltip-position="left">
+    tooltip-position="below">
     <md-icon>settings</md-icon>
   </button>
 </md-list-item>

--- a/src/app/pages/navigator/navigator.component.html
+++ b/src/app/pages/navigator/navigator.component.html
@@ -10,7 +10,7 @@
     id="igo-menu-button"
     class="igo-primary"
     [md-tooltip]="(sidenavOpened ? 'Close Menu' : 'Open Menu') | translate"
-    tooltip-position="left"
+    tooltip-position="below"
     (click)="toggleSidenav()">
     <md-icon>
       <ng-container *ngIf="!sidenavOpened">menu</ng-container>
@@ -41,7 +41,7 @@
           md-icon-button
           panelLeftButton
           [md-tooltip]="'Go Back' | translate"
-          tooltip-position="right"
+          tooltip-position="below"
           class="igo-icon-button"
           (click)="goBack()">
           <md-icon>arrow_back</md-icon>
@@ -51,7 +51,7 @@
           md-icon-button
           panelRightButton
           [md-tooltip]="'Main menu' | translate"
-          tooltip-position="left"
+          tooltip-position="below"
           class="igo-icon-button"
           (click)="goHome()">
           <md-icon>menu</md-icon>

--- a/src/app/pages/navigator/navigator.component.ts
+++ b/src/app/pages/navigator/navigator.component.ts
@@ -29,6 +29,8 @@ export class NavigatorComponent implements OnInit {
   sidenavOpened: boolean = false;
   selectedTool: Tool;
 
+  private toolHistory: Tool[] = [];
+
   constructor(private store: Store<IgoStore>,
               private mediaService: MediaService,
               private contextService: ContextService,
@@ -47,8 +49,7 @@ export class NavigatorComponent implements OnInit {
     this.store
       .select(s => s.selectedTool)
       .subscribe((tool: Tool) => {
-          this.selectedTool = tool;
-          this.menuState = 'initial';
+          this.handleToolSelected(tool);
       });
 
     this.store
@@ -64,12 +65,14 @@ export class NavigatorComponent implements OnInit {
       });
   }
 
-  unselectTool() {
-    this.store.dispatch({ type: 'UNSELECT_TOOL' });
-  }
-
   goBack() {
-    this.unselectTool();
+    const tool = this.toolHistory.pop();
+    if (tool !== undefined) {
+      this.selectedTool = tool;
+      this.selectTool(tool);
+    } else {
+      this.unselectTool();
+    }
   }
 
   goHome() {
@@ -100,5 +103,22 @@ export class NavigatorComponent implements OnInit {
 
   toggleToast() {
     this.toastState = this.toastState === 'initial' ? 'expanded' : 'initial';
+  }
+
+  private selectTool(tool: Tool) {
+    this.store.dispatch({type: 'SELECT_TOOL', payload: tool});
+  }
+
+  private unselectTool() {
+    this.store.dispatch({type: 'UNSELECT_TOOL'});
+  }
+
+  private handleToolSelected(tool?: Tool) {
+    if (tool && this.selectedTool && tool.name !== this.selectedTool.name) {
+      this.toolHistory.push(this.selectedTool);
+    }
+
+    this.selectedTool = tool;
+    this.menuState = 'initial';
   }
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines:https://github.com/infra-geo-ouverte/igo2/blob/master/.github/CONTRIBUTING.md#git-commit-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What is the current behavior?** (You can also link to an open issue here)
- No tool history ketp and go back simly unselect any tool


**What is the new behavior?**
- Tool history is kept and go back selected the previous tool


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications:


**Other information**:
