### PR TITLE
Layer refactor

### DIFF
--- a/src/app/map/layer-form/layer-form.component.ts
+++ b/src/app/map/layer-form/layer-form.component.ts
@@ -38,7 +38,7 @@ export class LayerFormComponent implements OnInit {
   }
 
   private populate() {
-    this.title.setValue(this.layer.options.title, {onlySelf: true});
+    this.title.setValue(this.layer.title, {onlySelf: true});
   }
 
 }

--- a/src/app/map/layer-list-item/layer-list-item.component.html
+++ b/src/app/map/layer-list-item/layer-list-item.component.html
@@ -8,7 +8,7 @@
     [collapsed]="layer.collapsed"
     (toggle)="toggleLegend($event)">
   </md-icon>
-  <h4 md-line>{{layer.options.title}}</h4>
+  <h4 md-line>{{layer.title}}</h4>
 
   <button
     md-icon-button

--- a/src/app/map/layer-list/layer-list.component.spec.ts
+++ b/src/app/map/layer-list/layer-list.component.spec.ts
@@ -4,6 +4,7 @@ import { TestModule } from '../../test.module';
 import { SharedModule } from '../../shared/shared.module';
 
 import { LayerService } from '../shared/layer.service';
+import { CapabilitiesService } from '../shared/capabilities.service';
 import { LayerListComponent } from './layer-list.component';
 import { LayerListItemComponent } from '../layer-list-item/layer-list-item.component';
 import { LayerLegendComponent } from '../layer-legend/layer-legend.component';
@@ -24,7 +25,8 @@ describe('LayerListComponent', () => {
         LayerLegendComponent
       ],
       providers: [
-        LayerService
+        LayerService,
+        CapabilitiesService
       ]
     })
     .compileComponents();

--- a/src/app/map/layer-list/layer-list.component.ts
+++ b/src/app/map/layer-list/layer-list.component.ts
@@ -17,7 +17,6 @@ import { LayerService } from '../shared/layer.service';
 export class LayerListComponent implements OnInit {
 
   @Input() map: IgoMap;
-  layers: Layer[];
 
   get edition (): boolean {
     return this.editTool !== undefined;

--- a/src/app/map/map-editor/map-editor.component.spec.ts
+++ b/src/app/map/map-editor/map-editor.component.spec.ts
@@ -6,6 +6,7 @@ import { SharedModule } from '../../shared/shared.module';
 import { IgoMap } from '../shared/map';
 import { MapService } from '../shared/map.service';
 import { LayerService } from '../shared/layer.service';
+import { CapabilitiesService } from '../shared/capabilities.service';
 import { MapEditorComponent } from './map-editor.component';
 import { LayerListComponent } from '../layer-list/layer-list.component';
 import { LayerListItemComponent } from '../layer-list-item/layer-list-item.component';
@@ -29,7 +30,8 @@ describe('MapEditorComponent', () => {
       ],
       providers: [
         MapService,
-        LayerService
+        LayerService,
+        CapabilitiesService
       ]
     })
     .compileComponents();

--- a/src/app/map/map.module.ts
+++ b/src/app/map/map.module.ts
@@ -4,6 +4,7 @@ import { ReactiveFormsModule } from '@angular/forms';
 
 import { MapService } from './shared/map.service';
 import { LayerService } from './shared/layer.service';
+import { CapabilitiesService } from './shared/capabilities.service';
 import { MapComponent } from './map/map.component';
 import { ZoomComponent } from './zoom/zoom.component';
 import { MapEditorComponent } from './map-editor/map-editor.component';
@@ -35,7 +36,8 @@ import { LayerLegendComponent } from './layer-legend/layer-legend.component';
   ],
   providers: [
     LayerService,
-    MapService
+    MapService,
+    CapabilitiesService
   ]
 })
 export class MapModule { }

--- a/src/app/map/map/map.component.spec.ts
+++ b/src/app/map/map/map.component.spec.ts
@@ -6,6 +6,7 @@ import { TestModule } from '../../test.module';
 
 import { MapService } from '../shared/map.service';
 import { LayerService } from '../shared/layer.service';
+import { CapabilitiesService } from '../shared/capabilities.service';
 import { IgoMap } from '../shared/map';
 import { ZoomComponent } from '../zoom/zoom.component';
 import { MapComponent } from './map.component';
@@ -33,7 +34,8 @@ describe('MapComponent', () => {
       providers: [
         {provide: Http, useValue: mockHttpProvider},
         MapService,
-        LayerService
+        LayerService,
+        CapabilitiesService
       ]
     })
     .compileComponents();

--- a/src/app/map/map/map.component.ts
+++ b/src/app/map/map/map.component.ts
@@ -64,13 +64,12 @@ export class MapComponent implements OnInit, AfterViewInit {
     return feature;
   }
 
-  private handleLayersChanged(layers: LayerOptions[]) {
+  private handleLayersChanged(layerOptions: LayerOptions[]) {
     this.map.removeLayers();
 
-    layers.forEach((layerOptions) => {
-      this.layerService.createLayer(layerOptions).subscribe(
-        layer => this.map.addLayer(layer)
-      );
+    layerOptions.forEach((options: LayerOptions) => {
+      this.layerService.createLayer(options).subscribe(
+        layer => this.map.addLayer(layer));
     });
   }
 

--- a/src/app/map/shared/capabilities.service.spec.ts
+++ b/src/app/map/shared/capabilities.service.spec.ts
@@ -1,0 +1,22 @@
+import { TestBed, inject } from '@angular/core/testing';
+
+import { TestModule } from '../../test.module';
+
+import { CapabilitiesService } from './capabilities.service';
+
+describe('CapabilitiesService', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        TestModule
+      ],
+      providers: [
+        CapabilitiesService
+      ]
+    });
+  });
+
+  it('should ...', inject([CapabilitiesService], (service: CapabilitiesService) => {
+    expect(service).toBeTruthy();
+  }));
+});

--- a/src/app/map/shared/capabilities.service.ts
+++ b/src/app/map/shared/capabilities.service.ts
@@ -1,0 +1,139 @@
+import { Injectable } from '@angular/core';
+import { Http, URLSearchParams, Response } from '@angular/http';
+import { Observable } from 'rxjs/Observable';
+
+import { RequestService } from '../../core/request.service';
+
+import { WMTSLayerOptions } from './layers/layer-wmts';
+import { WMSLayerOptions } from './layers/layer-wms';
+
+@Injectable()
+export class CapabilitiesService {
+
+  private capabilitiesStore: any[] = [];
+  private parsers = {
+    'wms': new ol.format.WMSCapabilities(),
+    'wmts': new ol.format.WMTSCapabilities()
+  };
+
+  constructor(private http: Http,
+              private requestService: RequestService) { }
+
+  getWMSOptions(baseOptions: WMSLayerOptions): Observable<WMSLayerOptions> {
+    const url = baseOptions.source.url;
+    const version = (baseOptions.source.params as any).version;
+
+    return this.getCapabilities('wms', url, version)
+      .map((capabilities: any) =>
+        this.parseWMSOptions(baseOptions, capabilities));
+  }
+
+  getWMTSOptions(baseOptions: WMTSLayerOptions): Observable<WMTSLayerOptions> {
+    const url = baseOptions.source.url;
+    const version = baseOptions.source.version;
+
+    const options = this.getCapabilities('wmts', url, version)
+      .map((capabilities: any) =>
+        this.parseWMTSOptions(baseOptions, capabilities));
+
+    return options;
+  }
+
+  private parseWMSOptions(baseOptions: WMSLayerOptions,
+                          capabilities: any): WMSLayerOptions {
+    const layers = (baseOptions.source.params as any).layers;
+    const layer = this.findLayerInCapabilities(
+      capabilities.Capability.Layer, layers);
+
+    const options: any = {};
+    if (layer.Title) {
+      // Save title under "alias" because we want to overwrite
+      // the default, mandatory title. If the title defined
+      // in the context is to be used along with the
+      // "optionsFromCapabilities" option, then it should be
+      // defined under "alias" in the context
+      options.alias = layer.Title;
+    }
+
+    if (layer.MaxScaleDenominator) {
+      options.maxResolution = layer.MaxScaleDenominator;
+    }
+
+    if (layer.MinScaleDenominator) {
+      options.minResolution = layer.MinScaleDenominator;
+    }
+
+    if (layer.DataURL && layer.DataURL[0] && layer.DataURL.OnlineResource) {
+      options.dataUrl = {
+        format: layer.DataURL[0].Format,
+        onlineResource: layer.DataURL[0].OnlineResource
+      };
+    }
+
+    return Object.assign(options, baseOptions);
+  }
+
+  private parseWMTSOptions(baseOptions: WMTSLayerOptions,
+                           capabilities: any): WMTSLayerOptions {
+    const sourceOptions = ol.source.WMTS.optionsFromCapabilities(
+      capabilities, baseOptions.source);
+
+    return Object.assign({}, baseOptions, {source: sourceOptions});
+  }
+
+  private getCapabilities(service: 'wms' | 'wmts',
+                          baseUrl: string,
+                          version?: string): Observable<any> {
+
+    const params = new URLSearchParams();
+    params.set('request', 'GetCapabilities');
+    params.set('service', service);
+    params.set('version', version || '1.3.0');
+
+    const url = baseUrl + '?' + params.toString();
+    const cached = this.capabilitiesStore.find(value => value.url === url);
+    if (cached !== undefined) {
+      return new Observable(c => c.next(cached.capabilities));
+    }
+
+    const request = this.http.get(baseUrl, {search: params});
+
+    return this.requestService.register(request)
+      .map((res: Response) => {
+        const capabilities = this.parsers[service].read(res.text());
+        this.cache(url, capabilities);
+
+        return capabilities;
+      });
+  }
+
+  private cache(url: string, capabilities: any) {
+    this.capabilitiesStore.push({
+      url: url,
+      capabilities: capabilities
+    });
+  }
+
+  /** Find a layer among capabilities's layers from it's name */
+  private findLayerInCapabilities(layerArray, name) {
+    if (Array.isArray(layerArray)) {
+      let layer;
+      layerArray.find(value => {
+        layer = this.findLayerInCapabilities(value, name);
+
+        return layer !== undefined;
+      }, this);
+
+      return layer;
+    } else if (layerArray.Layer) {
+      return this.findLayerInCapabilities(layerArray.Layer, name);
+    } else {
+      if (layerArray.Name && layerArray.Name === name) {
+        return layerArray;
+      }
+
+      return undefined;
+    }
+  }
+
+}

--- a/src/app/map/shared/layer.service.spec.ts
+++ b/src/app/map/shared/layer.service.spec.ts
@@ -1,12 +1,14 @@
 import { TestBed, inject } from '@angular/core/testing';
-
-import { LayerService } from './layer.service';
-
 import { MockBackend } from '@angular/http/testing';
 import {
     Http,
     BaseRequestOptions
 } from '@angular/http';
+
+import { TestModule } from '../../test.module';
+
+import { CapabilitiesService } from './capabilities.service';
+import { LayerService } from './layer.service';
 
 const mockHttpProvider = {
     deps: [ MockBackend, BaseRequestOptions ],
@@ -18,7 +20,14 @@ const mockHttpProvider = {
 describe('LayerService', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
-      providers: [ { provide: Http, useValue: mockHttpProvider }, LayerService]
+      imports: [
+        TestModule
+      ],
+      providers: [
+        { provide: Http, useValue: mockHttpProvider },
+        CapabilitiesService,
+        LayerService
+      ]
     });
   });
 

--- a/src/app/map/shared/layers/layer-osm.ts
+++ b/src/app/map/shared/layers/layer-osm.ts
@@ -7,7 +7,8 @@ export interface OSMLayerOptions extends LayerOptions {
 
 export class OSMLayer extends Layer {
 
-  options: OSMLayerOptions;
+  public options: OSMLayerOptions;
+
   protected olLayer: ol.layer.Tile;
 
   protected createOlLayer(): ol.layer.Tile {

--- a/src/app/map/shared/layers/layer-tile.ts
+++ b/src/app/map/shared/layers/layer-tile.ts
@@ -7,7 +7,8 @@ export interface TileLayerOptions extends LayerOptions {
 
 export class TileLayer extends Layer {
 
-  options: TileLayerOptions;
+  public options: TileLayerOptions;
+
   protected olLayer: ol.layer.Tile;
 
   protected createOlLayer(): ol.layer.Tile {

--- a/src/app/map/shared/layers/layer-vector.ts
+++ b/src/app/map/shared/layers/layer-vector.ts
@@ -8,7 +8,8 @@ export interface VectorLayerOptions extends LayerOptions {
 
 export class VectorLayer extends Layer {
 
-  options: VectorLayerOptions;
+  public options: VectorLayerOptions;
+
   protected olLayer: ol.layer.Vector;
 
   protected createOlLayer(): ol.layer.Vector {

--- a/src/app/map/shared/layers/layer-wms.ts
+++ b/src/app/map/shared/layers/layer-wms.ts
@@ -1,6 +1,6 @@
 import { Layer, LayerOptions, LayerLegendOptions} from './layer';
 
-export interface DataURL {
+export interface DataUrl {
   format: string;
   onlineResource: string;
 }
@@ -8,29 +8,38 @@ export interface DataURL {
 export interface WMSLayerOptions extends LayerOptions {
   source: olx.source.ImageWMSOptions;
   view?: olx.layer.TileOptions;
+  dataUrl?: DataUrl;
   optionsFromCapabilities?: boolean;
-  dataURL?: DataURL;
 }
 
 export class WMSLayer extends Layer {
 
-  options: WMSLayerOptions;
-  capabilities?: ol.format.XML;
+  public options: WMSLayerOptions;
+
   protected olLayer: ol.layer.Tile;
 
-  constructor(options: WMSLayerOptions, capabilities?: ol.format.XML) {
+  constructor(options: WMSLayerOptions) {
     // Important: To use wms versions smaller than 1.3.0, SRS
     // needs to be supplied in the source "params"
 
-    super(options);
-
     // We need to do this to override the default version
     // of openlayers which is uppercase
-    const sourceParams: any = this.options.source.params;
+    const sourceParams: any = options.source.params;
     if (sourceParams && sourceParams.version) {
       sourceParams.VERSION = sourceParams.version;
     }
-    this.capabilities = capabilities;
+
+    super(options);
+  }
+
+  protected createOlLayer(): ol.layer.Image {
+    const layerOptions = Object.assign({},
+      this.options.view || {},
+      this.options, {
+        source: new ol.source.ImageWMS(this.options.source)
+    });
+
+    return new ol.layer.Image(layerOptions);
   }
 
   getLegend(): LayerLegendOptions[] {
@@ -63,108 +72,6 @@ export class WMSLayer extends Layer {
     });
 
     return legend;
-  }
-
-  protected createOlLayer(): ol.layer.Image {
-    let layerOptions;
-    if (this.capabilities) {
-      const capabilityOptions = this.getOptionsFromCapabilities();
-      layerOptions = Object.assign(this.options.view || {}, capabilityOptions, {
-        source: new ol.source.ImageWMS(capabilityOptions.source)
-      });
-    } else {
-      layerOptions = Object.assign(this.options.view || {}, this.options, {
-        source: new ol.source.ImageWMS(this.options.source)
-      });
-    }
-    return new ol.layer.Image(layerOptions);
-  }
-
-  /** Get layer's properties from capabilities */
-  getOptionsFromCapabilities(): WMSLayerOptions {
-    const capabilities = this.capabilities as any;
-    const layer = this.findLayerInCapabilities(
-      capabilities.Capability.Layer,
-      this.options.source.params['layers']);
-
-    // TODO: getcapabilities attribution is not working
-    // let attribution;
-    // if (layer.Attribution) {
-    //   attribution = {
-    //     title: layer.Attribution.Title,
-    //     url: layer.Attribution.OnlineResource
-    //   };
-    // } else if (capabilities.Capability.Layer.Attribution) {
-    //   // TODO: support LogoURL
-    //   attribution = {
-    //     title: capabilities.Capability.Layer.Attribution.Title,
-    //     url: capabilities.Capability.Layer.Attribution.OnlineResource
-    //   };
-    // }
-    //
-    // if (attribution) {
-    //   Object.assign(options.source, {
-    //     'attributions': new ol.Attribution({
-    //       html: '<a href="' + attribution.onlineResource +
-    //       '" target="_blank">' +
-    //       attribution.title +
-    //       '</a>'
-    //     })
-    //   }
-    //   );
-    // }
-
-    const optionsFromCapabilities: any = {};
-    if (layer.Title) {
-      optionsFromCapabilities.title = layer.Title;
-    }
-
-    if (layer.MaxScaleDenominator) {
-      optionsFromCapabilities.maxResolution = layer.MaxScaleDenominator;
-    }
-
-    if (layer.MinScaleDenominator) {
-      optionsFromCapabilities.minResolution = layer.MinScaleDenominator;
-    }
-
-    if (layer.DataURL && layer.DataURL[0] && layer.DataURL.OnlineResource) {
-      optionsFromCapabilities.dataURL = {
-        format: layer.DataURL[0].Format,
-        onlineResource: layer.DataURL[0].OnlineResource
-      };
-    }
-
-    // TODO: getcapabilities bounding box (which EPSG ? use EX_GeographicBoundingBox ?)
-    // if(layer.BoundingBox) {
-    //   options.extent = [layer.BoundingBox[0].extent[0], layer.BoundingBox[0].extent[1],
-    //     layer.BoundingBox[0].extent[2], layer.BoundingBox[0].extent[3]];
-    // }
-
-    return Object.assign(optionsFromCapabilities, this.options);
-  }
-
-  /** Find a layer among capabilities's layers from it's name */
-  findLayerInCapabilities(layerArray, name) {
-    if (Array.isArray(layerArray)) {
-      let layer;
-      layerArray.find(value => {
-        layer = this.findLayerInCapabilities(value, name);
-        if (layer) {
-          return true;
-        }
-        return false;
-      }, this);
-      return layer;
-    } else if (layerArray.Layer) {
-      return this.findLayerInCapabilities(layerArray.Layer, name);
-    } else {
-      if (layerArray.Name) {
-        if (layerArray.Name === name) {
-          return layerArray;
-        }
-      }
-      return undefined;
-    }
   }
 
 }

--- a/src/app/map/shared/layers/layer-xyz.ts
+++ b/src/app/map/shared/layers/layer-xyz.ts
@@ -7,7 +7,8 @@ export interface XYZLayerOptions extends LayerOptions {
 
 export class XYZLayer extends Layer {
 
-  options: XYZLayerOptions;
+  public options: XYZLayerOptions;
+
   protected olLayer: ol.layer.Tile;
 
   protected createOlLayer(): ol.layer.Tile {

--- a/src/app/map/shared/layers/layer.ts
+++ b/src/app/map/shared/layers/layer.ts
@@ -54,7 +54,7 @@ export abstract class Layer {
     this.options = options;
 
     this.olLayer = this.createOlLayer();
-    if (options.index !== undefined) {
+    if (options.zIndex !== undefined) {
       this.zIndex = options.zIndex;
     }
 

--- a/src/app/map/shared/layers/layer.ts
+++ b/src/app/map/shared/layers/layer.ts
@@ -1,8 +1,10 @@
 export interface LayerOptions extends olx.layer.BaseOptions {
   title: string;
   type: string;
+  alias?: string;
   visible?: boolean;
   legend?: LayerLegendOptions;
+  zIndex?: number;
 }
 
 export interface LayerLegendOptions {
@@ -14,9 +16,23 @@ export interface LayerLegendOptions {
 
 export abstract class Layer {
 
-  options: LayerOptions;
-  collapsed: boolean;
+  public options: LayerOptions;
+
+  public collapsed: boolean;
+
   protected olLayer: ol.layer.Layer;
+
+  get title (): string {
+    return this.options.alias ? this.options.alias : this.options.title;
+  }
+
+  get zIndex (): number {
+    return this.olLayer.getZIndex();
+  }
+
+  set zIndex (zIndex: number) {
+    this.olLayer.setZIndex(zIndex);
+  }
 
   get visible (): boolean {
     return this.getOlLayer().get('visible');
@@ -36,6 +52,12 @@ export abstract class Layer {
 
   constructor(options: LayerOptions) {
     this.options = options;
+
+    this.olLayer = this.createOlLayer();
+    if (options.index !== undefined) {
+      this.zIndex = options.zIndex;
+    }
+
     this.visible = options.visible === undefined ? true : options.visible;
 
     const legend = options.legend || {};
@@ -45,10 +67,6 @@ export abstract class Layer {
   protected abstract createOlLayer(): ol.layer.Layer;
 
   getOlLayer() {
-    if (this.olLayer === undefined) {
-      this.olLayer = this.createOlLayer();
-    }
-
     return this.olLayer;
   }
 

--- a/src/app/store/reducers/layers.reducer.ts
+++ b/src/app/store/reducers/layers.reducer.ts
@@ -3,7 +3,8 @@ import { LayerOptions } from '../../map/shared/layers/layer';
 export function layers(state: Array<LayerOptions> = [], {type, payload}) {
   switch (type) {
     case 'SET_LAYERS':
-      return payload;
+      return payload.map((options: LayerOptions, index: number) =>
+        Object.assign({zIndex: index}, options));
     default:
       return state;
   }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines:https://github.com/infra-geo-ouverte/igo2/blob/master/.github/CONTRIBUTING.md#git-commit-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What is the current behavior?** (You can also link to an open issue here)
- The olLayer is not created in the layer constructor
- GetCapabilities options are out of sync between the olLayer and the layer itself
- GetCapabilities may break the layer order because of it's async nature
- Capabilities stuff are a bit spread out between the layer.service and the layers themselves
- The title in the capabilites was always overwritten by the title in the context

**What is the new behavior?**
- The olLayer is created in the layer constructor
- GetCapabilities are synced with the layer options (they're the same)
- Layer order is based on the zIndex and is kept consistent
- Capabilities service contains capabilities stuff
- The title is overwritten by the capabilities title via the new alias property
- It is possible to set a zIndex on a layer in the context
- The layer service has a different method for creating layers of each type which may allow
  more flexibility in the future


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications:


**Other information**:
