### PR TITLE
feat(time analyser): add temporary datepickers to the time analyser

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "angular2-notifications": "^0.4.53",
     "core-js": "^2.4.1",
     "hammerjs": "^2.0.8",
+    "md2": "0.0.18",
     "ng2-translate": "^5.0.0",
     "openlayers": "^4.0.1",
     "proj4": "^2.4.3",

--- a/src/app/analysis/analysis.module.ts
+++ b/src/app/analysis/analysis.module.ts
@@ -1,5 +1,6 @@
 import { NgModule } from '@angular/core';
 import { ReactiveFormsModule } from '@angular/forms';
+import { Md2Module } from 'md2';
 
 import { SharedModule } from '../shared/shared.module';
 
@@ -15,7 +16,8 @@ import {
 @NgModule({
   imports: [
     SharedModule,
-    ReactiveFormsModule
+    ReactiveFormsModule,
+    Md2Module
   ],
   declarations: [
     TimeAnalyserComponent,

--- a/src/app/analysis/time-analyser-form/time-analyser-form.component.html
+++ b/src/app/analysis/time-analyser-form/time-analyser-form.component.html
@@ -1,15 +1,42 @@
 <div *ngIf="!isRange">
   <div class="igo-col igo-col-100 igo-col-100-m">
-  <!-- Date picker will go here -->
+    <md2-datepicker
+      placeholder="{{'Date' | translate}}"
+      container="dialog"
+      format="{{format}}"
+      type="{{type}}"
+      [min]="min"
+      [max]="max"
+      [(ngModel)]="date"
+      (change)="handleDateChange($event)">
+    </md2-datepicker>
   </div>
 </div>
 
 <div *ngIf="isRange">
-  <div class="igo-col igo-col-50 igo-col-100-m">
-    <!-- Min date picker will go here -->
+  <div class="igo-col igo-col-100">
+    <md2-datepicker
+      placeholder="{{'Start Date' | translate}}"
+      container="dialog"
+      format="{{format}}"
+      type="{{type}}"
+      [min]="min"
+      [max]="max"
+      [(ngModel)]="startDate"
+      (change)="handleDateChange($event)">
+    </md2-datepicker>
   </div>
 
-  <div class="igo-col igo-col-50 igo-col-100-m">
-    <!-- Max date picker will go here -->
+  <div class="igo-col igo-col-100">
+    <md2-datepicker
+      placeholder="{{'End Date' | translate}}"
+      container="dialog"
+      format="{{format}}"
+      type="{{type}}"
+      [min]="min"
+      [max]="max"
+      [(ngModel)]="endDate"
+      (change)="handleDateChange($event)">
+    </md2-datepicker>
   </div>
 </div>

--- a/src/app/analysis/time-analyser-form/time-analyser-form.component.spec.ts
+++ b/src/app/analysis/time-analyser-form/time-analyser-form.component.spec.ts
@@ -1,4 +1,5 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { Md2Module } from 'md2';
 
 import { SharedModule } from '../../shared/shared.module';
 
@@ -11,7 +12,8 @@ describe('TimeAnalyserFormComponent', () => {
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       imports: [
-        SharedModule
+        SharedModule,
+        Md2Module
       ],
       declarations: [ TimeAnalyserFormComponent ]
     })

--- a/src/app/analysis/time-analyser-form/time-analyser-form.component.styl
+++ b/src/app/analysis/time-analyser-form/time-analyser-form.component.styl
@@ -2,7 +2,8 @@
 
 md2-datepicker {
   margin: 0 auto;
-  max-width: 170px;
+  width: 80%;
+  max-width: 80%;
 
   +media(mobile) {
     width: 80%;

--- a/src/app/analysis/time-analyser-form/time-analyser-form.component.ts
+++ b/src/app/analysis/time-analyser-form/time-analyser-form.component.ts
@@ -1,11 +1,13 @@
-import { Component, OnInit, Input, Output, EventEmitter } from '@angular/core';
+import { Component, Input, Output, EventEmitter } from '@angular/core';
 
 export interface TimeFilterOptions {
-  min: string;
-  max: string;
+  min?: string;
+  max?: string;
   range?: boolean;
   value?: string;
   values?: [string, string];
+  type?: 'date' | 'time' | 'datetime';
+  format?: string;
 }
 
 @Component({
@@ -13,41 +15,45 @@ export interface TimeFilterOptions {
   templateUrl: './time-analyser-form.component.html',
   styleUrls: ['./time-analyser-form.component.styl']
 })
-export class TimeAnalyserFormComponent implements OnInit {
+export class TimeAnalyserFormComponent {
 
   @Input() options: TimeFilterOptions;
   @Output() change: EventEmitter<Date | [Date | Date]> = new EventEmitter();
 
-  public type: 'date' | 'time' | 'datetime' = 'datetime';
-  public format: string = 'YYYY/MM/DD HH:mm';
+  public date: Date;
+  public startDate: Date;
+  public endDate: Date;
 
-  public _date: any;
-  public _minDate: any;
-  public _maxDate: any;
+  get type(): 'date' | 'time' | 'datetime' {
+    return this.options.type === undefined ?
+      'date' : this.options.type;
+  }
+
+  get format(): string {
+    return this.options.format === undefined ?
+      'y/MM/dd HH:mm' : this.options.format;
+  }
 
   get isRange(): boolean {
-    return this.options.range === undefined ? false : this.options.range;
+    return this.options.range === undefined ?
+      false : this.options.range;
   }
 
-  get date(): Date {
-    return this._date ? new Date(this._date) : undefined;
+  get min(): Date {
+    return this.options.min === undefined ?
+      undefined : new Date(this.options.min);
   }
 
-  get minDate(): Date {
-    return this._minDate ? new Date(this._minDate) : new Date(this.options.min);
-  }
-
-  get maxDate(): Date {
-    return this._maxDate ? new Date(this._maxDate) : new Date(this.options.max);
+  get max(): Date {
+    return this.options.max === undefined ?
+      undefined : new Date(this.options.max);
   }
 
   constructor() { }
 
-  ngOnInit() { }
-
   handleDateChange(event: any) {
     if (this.isRange) {
-      this.change.emit([this.minDate, this.maxDate]);
+      this.change.emit([this.startDate, this.endDate]);
     } else {
       this.change.emit(this.date);
     }

--- a/src/app/analysis/time-analyser-list-item/time-analyser-list-item.component.spec.ts
+++ b/src/app/analysis/time-analyser-list-item/time-analyser-list-item.component.spec.ts
@@ -1,4 +1,5 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { Md2Module } from 'md2';
 
 import { SharedModule } from '../../shared/shared.module';
 
@@ -16,7 +17,8 @@ describe('TimeAnalyserItemComponent', () => {
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       imports: [
-        SharedModule
+        SharedModule,
+        Md2Module
       ],
       declarations: [
         TimeAnalyserListItemComponent,

--- a/src/app/analysis/time-analyser-list-item/time-analyser-list-item.component.styl
+++ b/src/app/analysis/time-analyser-list-item/time-analyser-list-item.component.styl
@@ -1,0 +1,3 @@
+.igo-layer-filters-container {
+  text-align: center;
+}

--- a/src/app/analysis/time-analyser-list/time-analyser-list.component.spec.ts
+++ b/src/app/analysis/time-analyser-list/time-analyser-list.component.spec.ts
@@ -1,4 +1,5 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { Md2Module } from 'md2';
 
 import { SharedModule } from '../../shared/shared.module';
 import { IgoMap } from '../../map/shared/map';
@@ -18,7 +19,8 @@ describe('TimeAnalyserListComponent', () => {
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       imports: [
-        SharedModule
+        SharedModule,
+        Md2Module
       ],
       declarations: [
         TimeAnalyserListComponent,

--- a/src/app/analysis/time-analyser/time-analyser.component.spec.ts
+++ b/src/app/analysis/time-analyser/time-analyser.component.spec.ts
@@ -1,4 +1,5 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { Md2Module } from 'md2';
 
 import { SharedModule } from '../../shared/shared.module';
 
@@ -22,7 +23,8 @@ describe('TimeAnalyserComponent', () => {
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       imports: [
-        SharedModule
+        SharedModule,
+        Md2Module
       ],
       declarations: [
         TimeAnalyserComponent,

--- a/src/contexts/embacle.json
+++ b/src/contexts/embacle.json
@@ -38,6 +38,12 @@
           "layers": "vg_observation_v_inondation_embacle_wmst",
           "version": "1.3.0"
         }
+      },
+      "timeFilter": {
+        "min": "2017-01-01",
+        "max": "2018-01-01",
+        "range": true,
+        "type": "datetime"
       }
     }
   ],


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines:https://github.com/infra-geo-ouverte/igo2/blob/master/.github/CONTRIBUTING.md#git-commit-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What is the current behavior?** (You can also link to an open issue here)
- No datepicker in the time analyser because material doesn't support it yet


**What is the new behavior?**
- New library (ng2) with a datepicker. These datepickers will probably be replaced and the lib removed when material releases it's own datepicker.


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications:


**Other information**:
