### PR TITLE
Load tool once, not at every context change.

### DIFF
--- a/src/app/pages/portal/portal.component.ts
+++ b/src/app/pages/portal/portal.component.ts
@@ -56,6 +56,8 @@ export class PortalComponent implements OnInit, OnDestroy {
 
   // True after the initial context is loaded
   private contextLoaded = false;
+  // True after the initial tool is loaded
+  private toolLoaded = false;
 
   constructor(
     private route: ActivatedRoute,
@@ -217,14 +219,15 @@ export class PortalComponent implements OnInit, OnDestroy {
       if (params['layers'] && params['wmsUrl']) {
         this.addLayerByName(params['wmsUrl'], params['layers']);
       }
-      if (params['tool']) {
+      if (params['tool'] && !this.toolLoaded) {
         const toolNameToOpen = params['tool'];
         if (this.toolService.allowedToolName.indexOf(toolNameToOpen) !== -1) {
           const tool = this.toolService.getTool(toolNameToOpen);
           setTimeout(() => {
             this.toolService.selectTool(tool);
-          }, 1); // add delay for translationservice to be injected
+          }, 250); // add delay for translationservice to be injected
         }
+        this.toolLoaded = true;
       }
     });
   }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines:https://github.com/infra-geo-ouverte/igo2/blob/master/.github/CONTRIBUTING.md#git-commit-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What is the current behavior?** (You can also link to an open issue here)
1- If we change of context, the defined tool in url was coming back again and again.
2- If timeout is set to 1ms, seem to be not enough.


**What is the new behavior?**
1- Only open tool once,
2- higher delay.


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications:


**Other information**:
