### PR TITLE
fix(context): visible property adjustment (default context)

### DIFF
--- a/src/contexts/_default.json
+++ b/src/contexts/_default.json
@@ -12,7 +12,7 @@
     {
       "title": "OSM",
       "baseLayer": true,
-      "visible": true,
+      "visible": false,
       "sourceOptions": {
         "type": "osm"
       }

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -27,10 +27,10 @@ export const environment: Environment = {
       tokenKey: 'id_token_igo',
       allowAnonymous: true
     },
-/*     context: {
-      url: '/apis/igo2',
-      defaultContextUri: '5'
-    }, */
+    // context: {
+    //   url: '/apis/igo2',
+    //   defaultContextUri: '5'
+    // },
     searchSources: {
       nominatim: {
         available: false


### PR DESCRIPTION
Visible property adjustment in default context so it can't have two active baselayers. 