### PR TITLE
ui(toast-panel): igo-backdrop shown when tablet and portrait (igo#315)

### DIFF
--- a/src/app/pages/portal/portal.component.ts
+++ b/src/app/pages/portal/portal.component.ts
@@ -152,7 +152,7 @@ export class PortalComponent implements OnInit, OnDestroy {
 
   get backdropShown(): boolean {
     return (
-      this.mediaService.media$.value === Media.Mobile && this.sidenavOpened
+      (this.isMobile() || (this.isTablet() && this.isPortrait())) && this.sidenavOpened
     );
   }
 


### PR DESCRIPTION
igo-backdrop is now shown when media is Tablet and Orientation is Portrait. 

github issue igo2 #315 