### PR TITLE
feat(toast-panel) add zoom button on selected feature

### DIFF
--- a/src/app/pages/portal/toast-panel/toast-panel.component.html
+++ b/src/app/pages/portal/toast-panel/toast-panel.component.html
@@ -19,7 +19,9 @@
       [disabled]="results[0].meta.id === resultSelected$.value.meta.id"
       mat-icon-button
       igoStopPropagation
-      panelLeftButton
+      panelLeftButton      
+      [matTooltip]="'toastPanel.previousFeature' | translate"
+      matTooltipShowDelay="500"
       (click)="previousResult()">
       <mat-icon svgIcon="chevron-left"></mat-icon>
     </button>
@@ -30,8 +32,21 @@
       mat-icon-button
       igoStopPropagation
       panelRightButton
+      [matTooltip]="'toastPanel.nextFeature' | translate"
+      matTooltipShowDelay="500"
       (click)="nextResult()">
       <mat-icon svgIcon="chevron-right"></mat-icon>
+    </button>
+
+    <button 
+      *ngIf="resultSelected$.value" 
+      mat-icon-button 
+      igoStopPropagation 
+      panelRightButton
+      [matTooltip]="'toastPanel.zoomTo' | translate" 
+      matTooltipShowDelay="500" 
+      (click)="zoomTo()">
+      <mat-icon svgIcon="magnify-plus-outline"></mat-icon>
     </button>
 
     <button

--- a/src/app/pages/portal/toast-panel/toast-panel.component.html
+++ b/src/app/pages/portal/toast-panel/toast-panel.component.html
@@ -16,6 +16,15 @@
 
     <button
       *ngIf="resultSelected$.value"
+      disabled
+      mat-icon-button
+      igoStopPropagation
+      panelLeftButton>
+      <mat-icon svgIcon="blank"></mat-icon>
+    </button>
+    
+    <button
+      *ngIf="resultSelected$.value"
       [disabled]="results[0].meta.id === resultSelected$.value.meta.id"
       mat-icon-button
       igoStopPropagation

--- a/src/app/pages/portal/toast-panel/toast-panel.component.html
+++ b/src/app/pages/portal/toast-panel/toast-panel.component.html
@@ -20,7 +20,7 @@
       mat-icon-button
       igoStopPropagation
       panelLeftButton      
-      [matTooltip]="'toastPanel.previousFeature' | translate"
+      [matTooltip]="'toastPanel.previousFeatureTooltip' | translate"
       matTooltipShowDelay="500"
       (click)="previousResult()">
       <mat-icon svgIcon="chevron-left"></mat-icon>
@@ -32,7 +32,7 @@
       mat-icon-button
       igoStopPropagation
       panelRightButton
-      [matTooltip]="'toastPanel.nextFeature' | translate"
+      [matTooltip]="'toastPanel.nextFeatureTooltip' | translate"
       matTooltipShowDelay="500"
       (click)="nextResult()">
       <mat-icon svgIcon="chevron-right"></mat-icon>
@@ -43,7 +43,7 @@
       mat-icon-button 
       igoStopPropagation 
       panelRightButton
-      [matTooltip]="'toastPanel.zoomTo' | translate" 
+      [matTooltip]="'toastPanel.zoomOnFeatureTooltip' | translate" 
       matTooltipShowDelay="500" 
       (click)="zoomTo()">
       <mat-icon svgIcon="magnify-plus-outline"></mat-icon>

--- a/src/app/pages/portal/toast-panel/toast-panel.component.ts
+++ b/src/app/pages/portal/toast-panel/toast-panel.component.ts
@@ -319,6 +319,14 @@ export class ToastPanelComponent implements OnInit {
     }
   }
 
+  zoomTo() {
+    const olFeature = this.format.readFeature(this.resultSelected$.getValue().data, {
+      dataProjection: this.resultSelected$.getValue().data.projection,
+      featureProjection: this.map.projection
+    });
+    moveToOlFeatures(this.map, [olFeature], FeatureMotion.Default);
+  }
+
   swipe(action: string) {
     if (action === ToastPanelComponent.SWIPE_ACTION.RIGHT) {
       this.previousResult();

--- a/src/app/pages/portal/toast-panel/toast-panel.component.ts
+++ b/src/app/pages/portal/toast-panel/toast-panel.component.ts
@@ -324,7 +324,7 @@ export class ToastPanelComponent implements OnInit {
       dataProjection: this.resultSelected$.getValue().data.projection,
       featureProjection: this.map.projection
     });
-    moveToOlFeatures(this.map, [olFeature], FeatureMotion.Default);
+    moveToOlFeatures(this.map, [olFeature], FeatureMotion.Zoom);
   }
 
   swipe(action: string) {

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -9,14 +9,13 @@
     "listButton": "Return to the list of entities",
     "backToList": "Return to the list",
     "zoomOnFeature": "Zoom on feature",
-    "zoomOnFeatureTooltip": "Zoom on selected feature",
+    "zoomOnFeatureTooltip": "Zoom on selected feature ( shortcut = z )",
     "zoomOnFeatures": "Zoom on all features",
     "zoomOnFeaturesTooltip": "Zoom on all the selected features",
     "zoomAuto": "Zoom auto",
     "zoomAutoTooltip": "Automatic zoom",
-    "previousFeature": "Previous feature ( shortcut = left arrow)",
-    "nextFeature": "Next feature ( shortcut = right arrow)",
-    "zoomTo": "Zoom on current feature ( shortcut = z )"
+    "previousFeatureTooltip": "Previous feature ( shortcut = left arrow)",
+    "nextFeatureTooltip": "Next feature ( shortcut = right arrow)"
   },
   "IGO": "IGO",
   "noEntityStore": "No tables available for this dataset",

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -13,7 +13,10 @@
     "zoomOnFeatures": "Zoom on all features",
     "zoomOnFeaturesTooltip": "Zoom on all the selected features",
     "zoomAuto": "Zoom auto",
-    "zoomAutoTooltip": "Automatic zoom"
+    "zoomAutoTooltip": "Automatic zoom",
+    "previousFeature": "Previous feature ( shortcut = left arrow)",
+    "nextFeature": "Next feature ( shortcut = right arrow)",
+    "zoomTo": "Zoom on current feature ( shortcut = z )"
   },
   "IGO": "IGO",
   "noEntityStore": "No tables available for this dataset",

--- a/src/locale/fr.json
+++ b/src/locale/fr.json
@@ -13,7 +13,10 @@
     "zoomOnFeatures": "Zoom sur les éléments",
     "zoomOnFeaturesTooltip": "Zoomer sur les éléments sélectionnés",
     "zoomAuto": "Zoom auto",
-    "zoomAutoTooltip": "Zoom automatique"
+    "zoomAutoTooltip": "Zoom automatique",
+    "previousFeature": "Élément précédent ( raccouci clavier = flèche gauche )",
+    "nextFeature": "Prochain élément ( raccouci clavier = flèche droite )",
+    "zoomTo": "Zoom sur l'élément en cours ( raccouci clavier = z )"
   },
   "IGO": "IGO",
   "noEntityStore": "Aucune table disponible pour ce jeu de données",

--- a/src/locale/fr.json
+++ b/src/locale/fr.json
@@ -9,14 +9,13 @@
     "listButton": "Retourner à la liste des entités",
     "backToList": "Retourner à la liste",
     "zoomOnFeature": "Zoom sur l'élément",
-    "zoomOnFeatureTooltip": "Zoomer sur l'élément sélectionné",
+    "zoomOnFeatureTooltip": "Zoomer sur l'élément sélectionné ( raccouci clavier = z )",
     "zoomOnFeatures": "Zoom sur les éléments",
     "zoomOnFeaturesTooltip": "Zoomer sur les éléments sélectionnés",
     "zoomAuto": "Zoom auto",
     "zoomAutoTooltip": "Zoom automatique",
-    "previousFeature": "Élément précédent ( raccouci clavier = flèche gauche )",
-    "nextFeature": "Prochain élément ( raccouci clavier = flèche droite )",
-    "zoomTo": "Zoom sur l'élément en cours ( raccouci clavier = z )"
+    "previousFeatureTooltip": "Élément précédent ( raccouci clavier = flèche gauche )",
+    "nextFeatureTooltip": "Prochain élément ( raccouci clavier = flèche droite )"
   },
   "IGO": "IGO",
   "noEntityStore": "Aucune table disponible pour ce jeu de données",


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines:https://github.com/infra-geo-ouverte/igo2/blob/master/.github/CONTRIBUTING.md#git-commit-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What is the current behavior?** (You can also link to an open issue here)
To zoom on current feature, user must navigate into a contextual menu in the toast-panel header.


**What is the new behavior?**
Access to a zoom button inside the toast-panel header 
+ 
various tooltips


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```
