### PR TITLE
fix(toast-panel): zoom menu icon IE fix

### DIFF
--- a/src/app/pages/portal/toast-panel/toast-panel.component.scss
+++ b/src/app/pages/portal/toast-panel/toast-panel.component.scss
@@ -63,3 +63,7 @@ igo-feature-details ::ng-deep iframe {
 .swipe-fix {
   touch-action: pinch-zoom !important;
 }
+
+igo-actionbar {
+  overflow: hidden;
+}


### PR DESCRIPTION
- Fix zoom menu icon (toast-panel) for IE11