### PR TITLE
feat(toast-panel): add storage service for zoom auto and extended get…

### DIFF
--- a/src/app/pages/portal/portal.component.html
+++ b/src/app/pages/portal/portal.component.html
@@ -128,10 +128,7 @@
   [@toastPanelOffsetX]="(isMobile() || !isLandscape()) ? undefined : getExtent()"
   [@toastPanelOffsetY]="expansionPanelExpanded"
   [@toastPanelMobileSidenav]="(isMobile() && sidenavOpened) || (isTablet() && isPortrait() && sidenavOpened)"
-  [zoomAuto]="zoomAuto"
-  [fullExtent]="fullExtent"
   (openedChange)="toastOpenedChange($event)"
-  (zoomAutoEvent)="zoomAuto = $event"
   (fullExtentEvent)="fullExtent = $event">
 </app-toast-panel>
 

--- a/src/app/pages/portal/portal.component.ts
+++ b/src/app/pages/portal/portal.component.ts
@@ -98,7 +98,6 @@ export class PortalComponent implements OnInit, OnDestroy {
   public onSettingsChange$ = new BehaviorSubject<boolean>(undefined);
   public termDefinedInUrl = false;
   private addedLayers$$: Subscription[] = [];
-  public zoomAuto = false;
   public forceCoordsNA = false;
 
   public contextMenuStore = new ActionStore([]);


### PR DESCRIPTION
- Use the storage service to set user preference on the zoomAuto and the fullExtent parameters 

- Before, parameter is save in the same session

- Now, parameter is save in between sessions
