### PR TITLE
Add a emphasis feature for line and polygon too deep in view

### DIFF
--- a/docs/config_json.rst
+++ b/docs/config_json.rst
@@ -100,6 +100,14 @@ Résumé
                 les données WFS / Vectorielle / Cluster
                ** Encore en développement **
          -
+       * - `hasFeatureEmphasisOnSelection`
+         - Boolean
+         - .. line-block::
+               Permet d'ajouter à la carte une géométrie ponctuelle pour les entités 
+               linéaire ou polygonale sélectionnées ou survolées lors d'une 
+               interrogation de la carte et qui sont de trop petite taille par 
+               rapport à l'étendue de la carte. 
+         -
        * - importExport
          - `ImportExport`_
          - .. line-block::

--- a/src/app/pages/portal/portal.component.html
+++ b/src/app/pages/portal/portal.component.html
@@ -125,6 +125,7 @@
 <app-toast-panel *ngIf="!(queryStore.empty$ | async)"
   [map]="map"
   [store]="queryStore"
+  [hasFeatureEmphasisOnSelection]="hasFeatureEmphasisOnSelection"
   [@toastPanelOffsetX]="(isMobile() || !isLandscape()) ? undefined : getExtent()"
   [@toastPanelOffsetY]="expansionPanelExpanded"
   [@toastPanelMobileSidenav]="(isMobile() && sidenavOpened) || (isTablet() && isPortrait() && sidenavOpened)"

--- a/src/app/pages/portal/portal.component.ts
+++ b/src/app/pages/portal/portal.component.ts
@@ -101,6 +101,7 @@ import { WelcomeWindowService } from './welcome-window/welcome-window.service';
 export class PortalComponent implements OnInit, OnDestroy {
   public minSearchTermLength = 2;
   public hasExpansionPanel = false;
+  public hasFeatureEmphasisOnSelection: Boolean = false;
   public expansionPanelExpanded = false;
   public toastPanelOpened = true;
   public fullExtent;
@@ -271,6 +272,7 @@ export class PortalComponent implements OnInit, OnDestroy {
   ) {
     this.hasExpansionPanel = this.configService.getConfig('hasExpansionPanel');
     this.forceCoordsNA = this.configService.getConfig('app.forceCoordsNA');
+    this.hasFeatureEmphasisOnSelection = this.configService.getConfig('hasFeatureEmphasisOnSelection');
     this.igoSearchPointerSummaryEnabled = this.configService.getConfig(
       'hasSearchPointerSummary'
     );

--- a/src/config/config.json
+++ b/src/config/config.json
@@ -7,6 +7,7 @@
   "theme": "blue-theme",
   "hasExpansionPanel": false,
   "hasSearchPointerSummary": false,
+  "hasFeatureEmphasisOnSelection": true,
   "searchSources": {
     "cadastre": {
       "enabled": true


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines:https://github.com/infra-geo-ouverte/igo2/blob/master/.github/CONTRIBUTING.md#git-commit-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What is the current behavior?** (You can also link to an open issue here)
For query results -- Small line or polygon visible at a small scale were pratically invisible despite the highlight style


**What is the new behavior?**
Adding a pin point, based on the ration  feature extent/ view extent for line and poly. 
When zooming in

, if the previous ratio become under a threshold, the pin is removed.
It is possible the configurate the status of this feature. To disable the feature, under the app config.json, you can turn of this feature this way: 
```
 "hasFeatureEmphasisOnSelection": false,
```


![EXsAhFUqf0](https://user-images.githubusercontent.com/7397743/93542624-82b28600-f927-11ea-8ae1-f9aa9108d609.gif)






**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[ ] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications:


**Other information**:
