### PR TITLE
feat(portal) add config reverse menu button color 

### DIFF
--- a/docs/config_json.rst
+++ b/docs/config_json.rst
@@ -130,6 +130,11 @@ Résumé
          - .. line-block::
               Éléments visuels à ajouter par dessus la carte de l'application.
          -
+       * - menuButtonReverseColor
+         - Boolean
+         - .. line-block::
+              Indique si les couleurs du bouton de menu seront inversés.
+         -
        * - projections
          - :ref:`Projection <igoprojections>` []
          - .. line-block::
@@ -170,12 +175,12 @@ Résumé
          - .. line-block::
                Permet de définir le titre de l'application qu'on retrouve dans le menu d'accueil.
                Constante pouvant être réutilisée dans le welcomeWindow.
-         - 
+         -
       * - version
          - {app: String, releaseDateApp: String}
          - .. line-block::
                Permet de définir une constante, pour la version du présent déploiement et de la
-               date de déploiement de l'application. releaseDateApp, doit être un format reconnu et 
+               date de déploiement de l'application. releaseDateApp, doit être un format reconnu et
                interprétable au format Date. Si le format n'est pas convertissable en date,
                la valeur fournie sera utilisée directement.
                Constante pouvant être réutilisée dans le welcomeWindow.
@@ -196,7 +201,7 @@ Résumé
                   "title": "Fenêtre d'accueil",
                   "closeButton": "Fermer",
                   "notShowCheck": "  ne plus afficher"}
-               Les propriétés title, description, version, releaseDate peuvent être utilisé dans le contenu html 
+               Les propriétés title, description, version, releaseDate peuvent être utilisé dans le contenu html
                pour ajouter du contenu statique non traduit.
                ex: "html": "<h1>Débutez en sélectionnant un contexte &#x2605;</h2>Version {{version}}"
                - title provient de la propriété title ci haut.

--- a/src/app/pages/portal/portal.component.html
+++ b/src/app/pages/portal/portal.component.html
@@ -8,9 +8,8 @@
 
     <button
       mat-icon-button
-      id="menu-button"
-      class="menu-button"
-      color="primary"
+      id= "menu-button"
+      [ngClass]="getClassMenuButton()"
       tooltip-position="below"
       matTooltipShowDelay="500"
       [matTooltip]="(sidenavOpened ? 'menu.close' : 'menu.open') | translate"

--- a/src/app/pages/portal/portal.component.scss
+++ b/src/app/pages/portal/portal.component.scss
@@ -22,6 +22,25 @@
 
 /*** Menu button ***/
 
+.menu-button-reverse-color {
+  height: 40px;
+  position: absolute;
+  top: 3px;
+  z-index: 4;
+  border-radius: 0;
+  height: 45px;
+  width: 48px;
+}
+
+.menu-button-reverse-color-close {
+
+  position: absolute;
+  left: $igo-margin;
+  top: $igo-margin;
+  z-index: 4;
+  border-radius: 0;
+}
+
 .menu-button {
   background-color: $app-background-color;
   position: absolute;

--- a/src/app/pages/portal/portal.component.ts
+++ b/src/app/pages/portal/portal.component.ts
@@ -145,6 +145,7 @@ export class PortalComponent implements OnInit, OnDestroy {
   public selectedWorkspace$: BehaviorSubject<Workspace> = new BehaviorSubject(
     undefined
   );
+  private menuButtonReverseColor = false;
 
   @ViewChild('mapBrowser', { read: ElementRef, static: true })
   mapBrowser: ElementRef;
@@ -287,6 +288,9 @@ export class PortalComponent implements OnInit, OnDestroy {
     this.igoSearchPointerSummaryEnabled = this.configService.getConfig(
       'hasSearchPointerSummary'
     );
+    if (typeof this.configService.getConfig('menuButtonReverseColor') !== 'undefined') {
+      this.menuButtonReverseColor = this.configService.getConfig('menuButtonReverseColor');
+    }
   }
 
   ngOnInit() {
@@ -383,6 +387,20 @@ export class PortalComponent implements OnInit, OnDestroy {
         }
       }
     );
+  }
+
+  getClassMenuButton() {
+    if (this.sidenavOpened) {
+      return {
+        'menu-button': this.menuButtonReverseColor === false,
+        'menu-button-reverse-color': this.menuButtonReverseColor === true
+      };
+    } else {
+      return {
+        'menu-button': this.menuButtonReverseColor === false,
+        'menu-button-reverse-color-close ': this.menuButtonReverseColor === true
+      };
+    }
   }
 
   paginatorChange(matPaginator: MatPaginator) {

--- a/src/app/pages/portal/portal.theming.scss
+++ b/src/app/pages/portal/portal.theming.scss
@@ -5,4 +5,18 @@
   @include app-sidenav-theming($theme);
   @include igo-welcome-window-theming($theme);
   $primary: map-get($theme, primary);
+
+  .menu-button-reverse-color-close {
+    background-color: mat-color($primary);
+    color: mat-color($primary, default-contrast);
+  }
+
+  .menu-button-reverse-color {
+    background-color: mat-color($primary);
+    color: mat-color($primary, default-contrast);
+  }
+
+  .menu-button {
+    color: mat-color($primary);
+  }
 }

--- a/src/config/config.json
+++ b/src/config/config.json
@@ -8,6 +8,7 @@
   "hasExpansionPanel": true,
   "hasSearchPointerSummary": false,
   "hasFeatureEmphasisOnSelection": true,
+  "menuButtonReverseColor": false,
   "searchSources": {
     "cadastre": {
       "enabled": true


### PR DESCRIPTION

**What is the current behavior?** (You can also link to an open issue here)
https://github.com/infra-geo-ouverte/igo2/issues/486


**What is the new behavior?**
a new config is add:
"menuButtonReverseColor": true,
when is true the menu button color is reverse for theming color


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[ x] No
```

