### PR TITLE
fix(sidenav): close sidenav when result is selected in mobile

### DIFF
--- a/src/app/pages/portal/portal.component.ts
+++ b/src/app/pages/portal/portal.component.ts
@@ -346,6 +346,12 @@ export class PortalComponent implements OnInit, OnDestroy {
       this.searchState.setSearchSettingsChange();
     });
 
+    this.searchState.selectedResult$.subscribe((result) => {
+      if (result && this.isMobile()) {
+        this.closeSidenav();
+      }
+    })
+
     this.workspaceState.workspaceEnabled$.next(this.hasExpansionPanel);
     this.workspaceState.store.empty$.subscribe((workspaceEmpty) => {
       if (!this.hasExpansionPanel) {


### PR DESCRIPTION
- When on mobile and search result is selected, close the sidenav

- If not, map is too little to see clearly that something happened
