### PR TITLE
feat(about-tool): add link to IGO training guide

### DIFF
--- a/src/contexts/_base.json
+++ b/src/contexts/_base.json
@@ -165,7 +165,10 @@
       "name": "contextManager"
     },
     {
-      "name": "about"
+      "name": "about",
+      "options": {
+        "trainingGuideURL": "https://testgeoegl.msp.gouv.qc.ca/igo2/portail/particular/guides/IGO2-MSP_Guide_utilisateur.pdf"
+      }
     },
     {
       "name": "mapTools",


### PR DESCRIPTION
- Add IGO2 training guide url in about tool options

- When multiple guides will be available, multiple url's could be added
