### PR TITLE
feat(trainingGuide): allow training guide in depot config

### DIFF
--- a/src/environments/environment.github.ts
+++ b/src/environments/environment.github.ts
@@ -19,7 +19,7 @@ interface Environment {
     searchSources?: { [key: string]: SearchSourceOptions };
     projections?: Projection[];
     interactiveTour?: { tourInMobile: boolean; pathToConfigFile: string };
-    depot?: { url: string };
+    depot?: { url: string; trainingGuides?: string[]; };
     queryOverlayStyle?: {
       base?: CommonVectorStyleOptions,
       selection?: CommonVectorStyleOptions,

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -21,7 +21,7 @@ interface Environment {
     projections?: Projection[];
     spatialFilter?: SpatialFilterOptions;
     interactiveTour?: { tourInMobile: boolean; pathToConfigFile: string };
-    depot?: { url: string };
+    depot?: { url: string; trainingGuides?: string[]; };
     queryOverlayStyle?: {
       base?: CommonVectorStyleOptions,
       selection?: CommonVectorStyleOptions,

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -28,7 +28,7 @@ interface Environment {
     searchSources?: { [key: string]: SearchSourceOptions };
     projections?: Projection[];
     interactiveTour?: { tourInMobile: boolean; pathToConfigFile: string };
-    depot?: { url: string };
+    depot?: { url: string; trainingGuides?: string[]; };
     queryOverlayStyle?: {
       base?: CommonVectorStyleOptions,
       selection?: CommonVectorStyleOptions,


### PR DESCRIPTION
- Allow training guide url in depot config
- Input = string array
- If training guides are not defined in depot config, there must be context config url if you want to retrieve it from a specific profil