### PR TITLE
feat(portal): allow to control the initial extent by url

### DIFF
--- a/docs/url_control.rst
+++ b/docs/url_control.rst
@@ -63,9 +63,13 @@ Centre de la carte
 Étendue de la carte
 *******************************
 
+    Permet de zoomer à l'étendue désirée à l'ouverture de la carte.
     Les coordonnées sont en latitude longitude, selon la logique suivante
     [minx, miny, maxx, maxy]. Elles seront converties selon la projection
     de la carte.
+
+    Ce paramètre d'URL a été introduite  car le zoom et le center (par url) 
+    ne permettent pas d'obtenir le même résultat, par mobile, tablette ou bureau.
 
     Params :
         - zoomExtent=

--- a/docs/url_control.rst
+++ b/docs/url_control.rst
@@ -51,11 +51,27 @@ Zoom
 Centre de la carte
 *******************************
 
+    Les coordonnées sont en latitude longitude.
+
     Params :
         - center=
  
     Exemple:
         - https://infra-geo-ouverte.github.io/igo2/?center=-70.70426615422834,57.62669012416586
+
+*******************************
+Étendue de la carte
+*******************************
+
+    Les coordonnées sont en latitude longitude, selon la logique suivante
+    [minx, miny, maxx, maxy]. Elles seront converties selon la projection
+    de la carte.
+
+    Params :
+        - zoomExtent=
+ 
+    Exemple:
+        - https://infra-geo-ouverte.github.io/igo2/?zoomExtent=-72,60,-71,61
 
 *******************************
 Visibilité des couches

--- a/src/app/pages/portal/portal.component.ts
+++ b/src/app/pages/portal/portal.component.ts
@@ -984,7 +984,20 @@ export class PortalComponent implements OnInit, OnDestroy {
       this.readToolParams();
       this.readSearchParams();
       this.readFocusFirst();
+      this.computeZoomToExtent();
     });
+  }
+
+  private computeZoomToExtent() {
+    if (this.routeParams['zoomExtent']) {
+      const extentParams = this.routeParams['zoomExtent'].split(',');
+      const olExtent = olProj.transformExtent(
+        extentParams,
+        'EPSG:4326',
+        this.map.projection
+      );
+      this.map.viewController.zoomToExtent(olExtent as [number, number, number, number]);
+    }
   }
 
   private computeFocusFirst() {

--- a/src/app/pages/portal/portal.component.ts
+++ b/src/app/pages/portal/portal.component.ts
@@ -314,7 +314,7 @@ export class PortalComponent implements OnInit, OnDestroy {
   ) {
     this.hasExpansionPanel = this.configService.getConfig('hasExpansionPanel');
     this.hasGeolocateButton =
-    this.configService.getConfig('hasGeolocateButton') === undefined ? true : this.configService.getConfig('hasGeolocateButton') ;
+      this.configService.getConfig('hasGeolocateButton') === undefined ? true : this.configService.getConfig('hasGeolocateButton');
     this.showRotationButtonIfNoRotation =
       this.configService.getConfig('showRotationButtonIfNoRotation') === undefined ?
         false :
@@ -608,7 +608,7 @@ export class PortalComponent implements OnInit, OnDestroy {
   onSearchTermChange(term?: string) {
     if (this.routeParams?.search && term !== this.routeParams.search) {
       this.searchState.deactivateCustomFilterTermStrategy();
-  }
+    }
 
     this.searchState.setSearchTerm(term);
     const termWithoutHashtag = term.replace(/(#[^\s]*)/g, '').trim();
@@ -942,23 +942,23 @@ export class PortalComponent implements OnInit, OnDestroy {
         if (this.expansionPanelExpanded === false) {
           if (this.queryState.store.entities$.value.length === 0) {
             status = 'secondRowFromBottom';
-           } else {
+          } else {
             status = 'thirdRowFromBottom';
-           }
+          }
         } else {
           if (this.queryState.store.entities$.value.length === 0) {
             status = 'firstRowFromBottom-expanded';
-           } else {
+          } else {
             status = 'secondRowFromBottom-expanded';
-           }
+          }
         }
 
       } else {
         if (this.queryState.store.entities$.value.length === 0) {
           status = 'firstRowFromBottom';
-         } else {
+        } else {
           status = 'secondRowFromBottom';
-         }
+        }
       }
     } else {
       if (this.workspaceState.workspaceEnabled$.value) {
@@ -1037,24 +1037,24 @@ export class PortalComponent implements OnInit, OnDestroy {
       }
       if (this.routeParams['search'] && !this.routeParams['zoom'] && this.routeParams['sf'] !== '1') {
         const entities$$ = this.searchStore.stateView.all$()
-        .pipe(
-          skipWhile((entities) => entities.length === 0),
-          debounceTime(500),
-          take(1)
-        )
-        .subscribe((entities) => {
-          entities$$.unsubscribe();
-          const searchResultsOlFeatures = entities
-            .filter(e => e.entity.meta.dataType === FEATURE)
-            .map((entity: EntityRecord<SearchResult>) =>
-              new olFormatGeoJSON().readFeature(entity.entity.data, {
-                dataProjection: entity.entity.data.projection,
-                featureProjection: this.map.projection
-              })
-            );
+          .pipe(
+            skipWhile((entities) => entities.length === 0),
+            debounceTime(500),
+            take(1)
+          )
+          .subscribe((entities) => {
+            entities$$.unsubscribe();
+            const searchResultsOlFeatures = entities
+              .filter(e => e.entity.meta.dataType === FEATURE)
+              .map((entity: EntityRecord<SearchResult>) =>
+                new olFormatGeoJSON().readFeature(entity.entity.data, {
+                  dataProjection: entity.entity.data.projection,
+                  featureProjection: this.map.projection
+                })
+              );
             const totalExtent = computeOlFeaturesExtent(this.map, searchResultsOlFeatures);
             this.map.viewController.zoomToExtent(totalExtent);
-        });
+          });
       }
       this.searchBarTerm = this.routeParams['search'];
     }
@@ -1270,7 +1270,7 @@ export class PortalComponent implements OnInit, OnDestroy {
   private addLayerFromURL(
     url: string,
     name: string,
-    type: 'wms' | 'wmts' | 'arcgisrest'| 'imagearcgisrest' | 'tilearcgisrest',
+    type: 'wms' | 'wmts' | 'arcgisrest' | 'imagearcgisrest' | 'tilearcgisrest',
     version: string,
     visibility: boolean = true,
     zIndex: number
@@ -1293,7 +1293,7 @@ export class PortalComponent implements OnInit, OnDestroy {
       layer: name
     };
     if (type === 'wms') {
-      sourceOptions = { params: {LAYERS: name, VERSION: version}} as any;
+      sourceOptions = { params: { LAYERS: name, VERSION: version } } as any;
     }
 
     sourceOptions = ObjectUtils.removeUndefined(Object.assign({}, sourceOptions, commonSourceOptions));


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines:https://github.com/infra-geo-ouverte/igo2/blob/master/.github/CONTRIBUTING.md#git-commit-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What is the current behavior?** (You can also link to an open issue here)



**What is the new behavior?**
    Permet de zoomer à l'étendue désirée à l'ouverture de la carte. Les coordonnées sont en latitude longitude, selon la logique suivante [minx, miny, maxx, maxy]. Elles seront converties selon la projection de la carte.

La problématique vient du fait que le zoom et le center (par url) ne permettent pas d'obtenir le même résultat, par mobile, tablette ou bureau. 

    Params :
        - zoomExtent=

    Exemple:
        - https://infra-geo-ouverte.github.io/igo2/?zoomExtent=-72,60,-71,61


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[ ] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications:


**Other information**:
