### PR TITLE
Feat(app-component.ts) old browser add safari<=11 and IE11

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -68,9 +68,10 @@ export class AppComponent {
 
   private detectOldBrowser() {
     const oldBrowser = userAgent.satisfies({
-      ie: '<11',
+      ie: '<=11',
       chrome: '<64',
-      firefox: '<60'
+      firefox: '<60',
+      safari: '<=11'
     });
 
     if (oldBrowser) {


### PR DESCRIPTION
with safari <=11 swipe on map doesn't work.

**What is the new behavior?**
now safari <=11 and IE <=11 is detect as oldBrowser and a notice message is show


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x ] No
```


