### PR TITLE
feat(portal): initialextent button prise2

### DIFF
--- a/src/app/pages/portal/portal.component.html
+++ b/src/app/pages/portal/portal.component.html
@@ -71,6 +71,7 @@
         [@controlsOffsetY]="getControlsOffsetY()"
         [@mobileOffsetY]="getToastPanelStatus()">
       </igo-offline-button>
+      <igo-initial-button [map]="map" color="primary" ></igo-initial-button>
       <igo-geolocate-button
         *ngIf="hasGeolocateButton"
         [map]="map" color="primary"

--- a/src/app/pages/portal/portal.component.ts
+++ b/src/app/pages/portal/portal.component.ts
@@ -166,6 +166,7 @@ export class PortalComponent implements OnInit, OnDestroy {
   mapBrowser: ElementRef;
   @ViewChild('searchBar', { read: ElementRef, static: true })
   searchBar: ElementRef;
+  setInitialButton: any;
 
   get map(): IgoMap {
     return this.mapState.map;
@@ -316,7 +317,9 @@ export class PortalComponent implements OnInit, OnDestroy {
     this.hasExpansionPanel = this.configService.getConfig('hasExpansionPanel');
     this.hasGeolocateButton =
       this.configService.getConfig('hasGeolocateButton') === undefined ? true : this.configService.getConfig('hasGeolocateButton');
-    this.showRotationButtonIfNoRotation =
+    this.setInitialButton =
+       this.configService.getConfig('setInitialButton') === undefined ? true : this.configService.getConfig('setInitialButton') ;
+      this.showRotationButtonIfNoRotation =
       this.configService.getConfig('showRotationButtonIfNoRotation') === undefined ?
         false :
         this.configService.getConfig('showRotationButtonIfNoRotation');

--- a/src/config/config.json
+++ b/src/config/config.json
@@ -11,6 +11,11 @@
   },
   "theme": "blue-theme",
   "hasExpansionPanel": true,
+  "setInitialButton": {
+     "initExtent":[-9000000, 5790000,-7500000, 6770000],
+     "initCenter": [-73.938087, 49.000000],
+     "initZoom" : 6
+  },
   "hasGeolocateButton": true,
   "showRotationButtonIfNoRotation": false,
   "hasFeatureEmphasisOnSelection": true,

--- a/src/config/interactiveTour.json
+++ b/src/config/interactiveTour.json
@@ -146,6 +146,12 @@
         }
       },
       {
+        "element": "igo-initial-button",
+        "title": "interactiveTour.global.initial-title",
+        "text": "interactiveTour.global.initial",
+        "noBackButton": true
+      },
+      {
         "element": "igo-geolocate-button",
         "title": "interactiveTour.global.geolocate-title",
         "text": "interactiveTour.global.geolocate",

--- a/src/contexts/_base.json
+++ b/src/contexts/_base.json
@@ -2,7 +2,7 @@
   "map": {
     "view": {
       "projection": "EPSG:3857",
-      "center": [-71.938087, 48.446975],
+      "center": [-73.938087, 49.000000],
       "zoom": 6,
       "maxZoom": 19,
       "maxZoomOnExtent": 17

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -90,6 +90,8 @@
       "home-button": "This button allow to get back to main menu",
       "geolocate-title": "GEOLOCATE",
       "geolocate": "To zoom the map to your location.",
+      "initial-title": "INITIAL EXTENT",
+      "initial": "To return to the initial extent of the map",
       "user-title": "USER",
       "user-button": "To authenticate you or to disconnect and stay anonymous.",
       "baselayers-title": "BASELAYERS",

--- a/src/locale/fr.json
+++ b/src/locale/fr.json
@@ -89,6 +89,7 @@
       "tool-enter": "...son contenu s'affichera ici.",
       "home-button": "Ce bouton nous permet ensuite le retour au menu principal.",
       "geolocate-title": "GEOLOCALISATION",
+      "initial": "Pour retourner à l'étendue initiale de la carte",
       "geolocate": "Pour zoomer la carte sur votre position.",
       "user-title": "UTILISATEUR",
       "user-button": "Pour vous authentifier à IGO2 ou vous déconnecter et demeurer anonyme.",


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines:https://github.com/infra-geo-ouverte/igo2/blob/master/.github/CONTRIBUTING.md#git-commit-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What is the current behavior?** (You can also link to an open issue here)
The button to return to the initial extent of the map is missing


**What is the new behavior?**
There is a button to return to the initial extent of the map


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications:


**Other information**:
