### PR TITLE
fix(demo+docs) - ogc-filter-time

### DIFF
--- a/docs/_tables/fr/properties/filter/igoOgcFilterDuring.csv
+++ b/docs/_tables/fr/properties/filter/igoOgcFilterDuring.csv
@@ -1,12 +1,12 @@
 Propriétés,Type,Description,Valeurs possibles,Valeur défaut
-begin ,String ,Valeur de début du filtre temporel ,,Valeur **minDate** de la couche
-end ,String ,Valeur de fin du filtre temporel ,,Valeur **maxDate** de la couche
+begin ,String ,Valeur de début du filtre temporel. NB.: avec calendarModeYear il ne doit pas avoir de temps d'inscris,,Valeur **minDate** de la couche
+end ,String ,Valeur de fin du filtre temporel.NB.: avec calendarModeYear il ne doit pas avoir de temps d'inscris ,,Valeur **maxDate** de la couche
 step ,String ,Pas de temps défini selon la norme ISO-8601 ,Voir `Wiki<https://fr.wikipedia.org/wiki/ISO_8601#Dur%C3%A9e>`__ ,60000 millisecondes
-restrictedToStep ,Boolean, "| True si le filtre doit respecter le pas de temps depuis
+restrictToStep ,Boolean, "| True si le filtre doit respecter le pas de temps depuis
 | l'attribut **minDate**.
-|
+| En mode calendrier à true, n'affichera plus la date de fin, le filtre sera : date début + pas de temps.
 | Sinon le pas de temps est respecté selon l'attribut **begin**" ,True | False ,False
-calendarModeYearBoolean,,"| Lorsque true, l’interface présentera uniquement des
+calendarModeYear,Boolean,"| Lorsque true, l’interface présentera uniquement des
 | années et ajustera les requête aux service pour
 | que l’année de début et de fin soit incluse dans
 | le retour.",True | False ,False

--- a/docs/config_json.rst
+++ b/docs/config_json.rst
@@ -1249,7 +1249,10 @@ Message
 
     .. line-block::
 
-        Message affiché à l'ouverture du contexte
+        Message affiché à l'ouverture du contexte ou à l'ouverture de la couche.
+        - Une librairie tierce est utilisée pour l'affichage de message : `NGX-TOASTR  <https://www.npmjs.com/package/ngx-toastr>`_
+        NB.: Les classes connues de l'application peuvent être utilisées. Des classes personalisées spécifiques aux messages peuvent être ajoutés.
+         `IGO2 styles.scss <https://github.com/infra-geo-ouverte/igo2/blob/master/src/styles.scss#L13>`_  
 
 Exemples
 
@@ -1257,7 +1260,7 @@ Exemples
 
             "message": {
                   "format": "html",
-                  "html": " "<head><meta charset='utf-8'><style> .page{padding-left: 0px;margin-right:-45px;} </style> </head>  <body> <div class='page' style='color: white;'> Bienvenue sur <b>IGO</b></div> </body>",
+                  "html": "<div class='class-custom-rouge'> Bienvenue sur <b>IGO</b></div>",
                   "type": "info",
                   "options": {
                         "timeOut": 30000

--- a/docs/properties.rst
+++ b/docs/properties.rst
@@ -877,7 +877,11 @@ Configuration filtre attributaire OGC (ogcFilters)
     - Les outils ogcFilter et/ou activeOgcFilter doivent être activés dans les outils ('tools'). (Voir :ref:`igoactiveogcFilter` et :ref:`igoogcFilter` dans la section outil )
     - Pour activation des filtres avancés, ils est nécessaire de définir un objet sourceField pour les champs à filtrer. Référez-vous à: :ref:`igosourceFieldsObject`
     - Il est possible de définir plusieurs opérateurs sur un même filtre.
+    - les paramètres de sourceOptions maxDate et minDate sont comparés pour indiquer si le filtre temporel est actif (badge rouge dans les options de la couche). 
+    Si le param de sourceOptions optionsFromCapabilities est true les valeurs min et max peuvent provenir du service.
 
+    **NB**: Lorsqu'une couche a une échelle d'affichage définit dans le service, vous devez activer le paramètre dans sourceOptions -> optionsFromCapabilities:true. 
+    Dans le cas contraire, des apels contenant les filtres seront fait au service et ce, même à l'échelle ou la couche n'est pas affichée.
 
 Exemples
 ----------
@@ -1130,9 +1134,9 @@ Exemple - filtre temporel en mode année
                   "filters" :{
                         "operator": "During",
                         "propertyName": "annee_date",
-                        "begin": "1890-01-01T00:00:00-05:00",
-                        "end": "2021-12-31T00:00:00-05:00",
-                        "restrictedToStep": false,
+                        "begin": "1920",
+                        "end": "2020",
+                        "restrictToStep": false,
                         "calendarModeYear": true
                     } 
                   "stepDate": "P1Y"
@@ -1163,7 +1167,7 @@ Exemple - filtre avec boutons spécifique à un groupe et calendrier (filtrage t
                   ],
                   "ogcFilters": {
                         "enabled": true,
-                        "editable": true,
+                        "editable": false,
                         "pushButtons": {
                            "groups": [
                               {"title": "Group 1 Title","name": "1","ids": ["id1"]}
@@ -1693,9 +1697,9 @@ Exemple 1:
         RTSS: Cette storedQueries interroge un service WMS du `Ministère du Transport du Québec <https://ws.mapserver.transports.gouv.qc.ca/swtq?service=wfs&version=1.1.0&request=GetCapabilities>`__ qui peut retourner:
             - Route                                    ex: 138
             - Route tronçon                            ex: 13801
-            - Route tronçon section (RTS)              ex: 13801110
-            - Route tronçon section sous-route (RTSS)  ex: 0013801110000C
-            - RTSS Chainage                            ex: 0013801110000C+12
+            - Route tronçon section (RTS)              ex: 13801116
+            - Route tronçon section sous-route (RTSS)  ex: 0013801116000C
+            - RTSS Chainage                            ex: 0013801116000C+12
 
         Elle nécessite l'envoi au serveur de 2 attributs.
             - rtss
@@ -1772,7 +1776,7 @@ Liens
 
     - `Code Stored Queries Ligne 34 <https://github.com/infra-geo-ouverte/igo2-lib/blob/master/packages/geo/src/lib/search/shared/sources/storedqueries.ts#L34>`__
     - `Bug Openlayers et les GML 3.2+ en WFS(StoredQueries) <https://github.com/openlayers/openlayers/pull/6400>`__
-    - `Exemple d'appel StoredQueries rtss MTQ <https://ws.mapserver.transports.gouv.qc.ca/swtq?service=wfs&version=2.0.0&REQUEST=GetFeature&STOREDQUERY_ID=rtss&rtss=0013801110000C&chainage=0&outputformat=text/xml;%20subtype=gml/3.1.1&SRSNAME=epsg:4326>`__
+    - `Exemple d'appel StoredQueries rtss MTQ <https://ws.mapserver.transports.gouv.qc.ca/swtq?service=wfs&version=2.0.0&REQUEST=GetFeature&STOREDQUERY_ID=rtss&rtss=0013801116000C&chainage=0&outputformat=text/xml;%20subtype=gml/3.1.1&SRSNAME=epsg:4326>`__
     - `Exemple d'appel StoredQueries feuillet SNRC MFFP <https://geoegl.msp.gouv.qc.ca/ws/mffpecofor.fcgi?REQUEST=GetFeature&STOREDQUERY_ID=sq250et20kFeuillet&service=wfs&version=2.0.0&no_feuillet=31P08>`__
     - `Décrire la requête "rtss" <https://ws.mapserver.transports.gouv.qc.ca/swtq?service=wfs&version=2.0.0&request=DescribeStoredQueries&storedQuery_Id=rtss>`__
 

--- a/src/contexts/ogcFilters.json
+++ b/src/contexts/ogcFilters.json
@@ -4,8 +4,47 @@
   "base": "_base",
   "layers": [
     {
+      "title": "Feux forêt (WMS - filtre temps en calendrier-année)",
+      "visible": false,
+      "metadata": {
+          "extern": true
+      },
+
+      "sourceOptions": {
+          "crossOrigin": "anonymous",
+          "queryable": true,
+          "queryFormat": "htmlgml2",
+          "queryHtmlTarget": "iframe",
+          "type": "wms",
+          "url": "https://geoegl.msp.gouv.qc.ca/apis/ws/mffpecofor.fcgi",
+          "optionsFromCapabilities": true,
+          "params": {
+              "layers": "ca_feux_close_scale",
+              "version": "1.3.0"
+          },
+          "timeFilterable": false,
+          "ogcFilters": {
+              "enabled": true,
+              "editable": true,
+              "allowedOperatorsType": "basic",
+            
+              "filters":
+              {
+                "operator": "During",
+                "propertyName": "annee_date",
+                "begin": "1890",
+                "end": "2020",
+                "restrictedToStep": false,
+                "calendarModeYear": true
+              } 
+          },
+          "stepDate": "P1Y"
+      }    
+    }, 
+    {
       "id":"1",
-      "title": "WFS",
+      "title": "Filtre - Événements (WFS avec filtre avancé)",
+      "visible": false,
       "sourceOptions": {
         "type": "wfs",
         "url": "https://geoegl.msp.gouv.qc.ca/apis/ws/igo_gouvouvert.fcgi",
@@ -35,7 +74,7 @@
     },
     {
       "id":"2",
-      "title": "Filtre - Événements extrêmes",
+      "title": "Filtre - Événements extrêmes (non éditable)",
       "visible": false,
       "sourceOptions": {
         "queryable": true,
@@ -60,7 +99,7 @@
     },
     {
       "id":3,
-      "title": "Filterable WMS layers with predefined filters",
+      "title": "Filtre - Photo radard (WMS - boutons de différents types)",
       "sourceOptions": {
         "type": "wms",
         "url": "https://ws.mapserver.transports.gouv.qc.ca/swtq",
@@ -71,7 +110,7 @@
         },
         "ogcFilters": {
           "enabled": true,
-          "editable": true,
+          "editable": false,
           "pushButtons": {
             "order": 2,
             "groups": [
@@ -368,7 +407,7 @@
     },
     {
       "id":4,
-      "title": "Filterable WMS layers with predefined filters and time ogc",
+      "title": "Filtre - Événements (WMS- boutons + filtre temps calendrier-date)",
       "sourceOptions": {
         "type": "wms",
         "url": "https://geoegl.msp.gouv.qc.ca/apis/ws/igo_gouvouvert.fcgi",
@@ -390,7 +429,7 @@
         ],
         "ogcFilters": {
           "enabled": true,
-          "editable": true,
+          "editable": false,
           "pushButtons": {
             "groups": [
               {"title": "Group 1 Title","name": "1","ids": ["id1"]}
@@ -436,76 +475,8 @@
         "maxDate": "2025-12-31T00:00:00-05:00",
         "stepDate": "P1D"
       }
-    },
-    {
-      "title": "feu forêt Time-yearMode",
-      "visible": false,
-      "metadata": {
-          "extern": true
-      },
-
-      "sourceOptions": {
-          "crossOrigin": "anonymous",
-          "queryable": true,
-          "queryFormat": "htmlgml2",
-          "queryHtmlTarget": "iframe",
-          "type": "wms",
-          "url": "https://geoegl.msp.gouv.qc.ca/apis/ws/mffpecofor.fcgi",
-          "optionsFromCapabilities": true,
-          "params": {
-              "layers": "ca_feux",
-              "version": "1.3.0"
-          },
-          "timeFilterable": true,
-          "ogcFilters": {
-              "enabled": true,
-              "editable": false,
-              "allowedOperatorsType": "basic",
-              "pushButtons": {
-                  "groups": [
-                    {"title": "Group 1 Title","name": "1","ids": ["id1"]}
-                  ],
-                  "bundles": [
-                    {
-                      "id": "id1",
-                      "logical": "Or",
-                      "title": "Type feu",
-                      "selectors": [
-                      {
-                          "title": "total",
-                          "color": "0,137,123",
-                          "filters": {
-                              "operator": "PropertyIsEqualTo",
-                              "propertyName": "symbologie",
-                              "expression": "BR"
-                          }
-                      },
-                        {
-                          "title": "partiel",
-                          "color": "0,137,123",
-                          "filters": {
-                            "operator": "PropertyIsEqualTo",
-                            "propertyName": "symbologie",
-                            "expression": "BRP"
-                          }
-                        }
-                      ]
-                    }
-                  ]
-              },
-              "filters":
-              {
-                "operator": "During",
-                "propertyName": "annee_date",
-                "begin": "1890-01-01T00:00:00-05:00",
-                "end": "2021-12-31T00:00:00-05:00",
-                "restrictedToStep": false,
-                "calendarModeYear": true
-              } 
-          },
-          "stepDate": "P1Y"
-      }    
-    } 
+    }
+   
   ],
   "toolbar": [
     "searchResults",


### PR DESCRIPTION
fix demo pour contexte filtre attributaire: 
- Changement des titres de couche
- Retrait de filtre avancé pour couches ayant des boutons

fix docs:
- filtre OGC: modif exemple temps année, fix coquille sur param restrictStep. Ajout précision sur fonctionnement badge pour filtre temporel. Ajout de précisions sur optionsFromCapabilities:true VS filtreOGC 
- storedQuery, change exemple MTQ call stored query 110 -> 116
- message add new info sur la librairie ngx-toaster

