### PR TITLE
feat(portal): new homeExtent button

### DIFF
--- a/docs/_tables/fr/properties/map-view.csv
+++ b/docs/_tables/fr/properties/map-view.csv
@@ -6,6 +6,8 @@ center ,Array [] ,"| Coordonnée du positionnement du centre de la carte
 | l'arrivée dans le contexte. ",,
 zoom ,Number,"| Indique le niveau de zoom de la carte lors de 
 | l'arrivée dans le contexte. ",,
+homeExtentButtonExtent ,String,"| Coordonnées de l'étendue de la carte lorsque l'utilisateur
+| clique sur le bouton homeExtent. ","MINX | MINY | MAXX | MAXY",
 geolocate ,Boolean,"| Indique si la carte est zommée sur la localisation de l'utilisateur 
 | lors de l'arrivée dans le contexte. ",true | false,true
 maxZoomOnExtent ,Number,"| Indique le niveau de zoom qu'aura l'application lors d'un clic 

--- a/src/app/pages/portal/portal.component.html
+++ b/src/app/pages/portal/portal.component.html
@@ -78,6 +78,7 @@
         [@mobileOffsetY]="getToastPanelStatus()">
       </igo-geolocate-button>
       <igo-rotation-button [showIfNoRotation]="showRotationButtonIfNoRotation" [map]="map" color="primary"></igo-rotation-button>
+      <igo-home-extent-button [map]="map" color="primary"></igo-home-extent-button>
       <igo-user-button 
         *ngIf="auth.url"
         [map]="map" color="primary"

--- a/src/app/pages/portal/portal.component.html
+++ b/src/app/pages/portal/portal.component.html
@@ -81,6 +81,9 @@
       <igo-home-extent-button
         *ngIf="hasHomeExtentButton"
         [map]="map"
+        [extentOverride]="homeExtent"
+        [centerOverride]="homeCenter"
+        [zoomOverride]="homeZoom"
         color="primary">
       </igo-home-extent-button>
       <igo-user-button

--- a/src/app/pages/portal/portal.component.html
+++ b/src/app/pages/portal/portal.component.html
@@ -78,7 +78,11 @@
         [@mobileOffsetY]="getToastPanelStatus()">
       </igo-geolocate-button>
       <igo-rotation-button [showIfNoRotation]="showRotationButtonIfNoRotation" [map]="map" color="primary"></igo-rotation-button>
-      <igo-home-extent-button [map]="map" color="primary"></igo-home-extent-button>
+      <igo-home-extent-button
+        *ngIf="hasHomeExtentButton"
+        [map]="map"
+        color="primary">
+      </igo-home-extent-button>
       <igo-user-button 
         *ngIf="auth.url"
         [map]="map" color="primary"

--- a/src/app/pages/portal/portal.component.scss
+++ b/src/app/pages/portal/portal.component.scss
@@ -287,6 +287,17 @@ igo-geolocate-button {
   }
 }
 
+igo-home-extent-button {
+  @include mobile {
+    margin-bottom: 0px;
+    right: calc((2 * #{$igo-icon-size}) +  (4 * #{$igo-margin}))
+  }
+  @include tablet {
+    margin-bottom: 0px;
+    right: calc((2 * #{$igo-icon-size}) +  (4 * #{$igo-margin}))
+  }
+}
+
 igo-zoom-button {
   @include tablet {
     display: none;

--- a/src/app/pages/portal/portal.component.ts
+++ b/src/app/pages/portal/portal.component.ts
@@ -64,7 +64,8 @@ import {
   FeatureWorkspace,
   generateIdFromSourceOptions,
   computeOlFeaturesExtent,
-  addStopToStore
+  addStopToStore,
+  MapExtent
 } from '@igo2/geo';
 
 import {
@@ -163,6 +164,9 @@ export class PortalComponent implements OnInit, OnDestroy {
   private routeParams: Params;
   public toastPanelHtmlDisplay = false;
 
+  public homeExtent: MapExtent
+  public homeCenter: [number, number];
+  public homeZoom: number;
   @ViewChild('mapBrowser', { read: ElementRef, static: true })
   mapBrowser: ElementRef;
   @ViewChild('searchBar', { read: ElementRef, static: true })
@@ -676,11 +680,26 @@ export class PortalComponent implements OnInit, OnDestroy {
     }
   }
 
+  private computeHomeExtentValues(context: DetailedContext) {
+    if (context?.map?.view?.homeExtent) {
+      this.homeExtent = context.map.view.homeExtent.extent;
+      this.homeCenter = context.map.view.homeExtent.center;
+      this.homeZoom = context.map.view.homeExtent.zoom;
+    } else {
+      this.homeExtent = undefined;
+      this.homeCenter = undefined;
+      this.homeZoom = undefined;
+    }
+
+  }
+
   private onChangeContext(context: DetailedContext) {
     this.cancelOngoingAddLayer();
     if (context === undefined) {
       return;
     }
+
+    this.computeHomeExtentValues(context);
 
     this.route.queryParams.pipe(debounceTime(250)).subscribe((qParams) => {
       if (!qParams['context'] || qParams['context'] === context.uri) {

--- a/src/app/pages/portal/portal.component.ts
+++ b/src/app/pages/portal/portal.component.ts
@@ -114,7 +114,7 @@ export class PortalComponent implements OnInit, OnDestroy {
   public minSearchTermLength = 2;
   public hasExpansionPanel = false;
   public hasGeolocateButton = true;
-  public setHomeExtentButton = true;
+  public hasHomeExtentButton = false;
   public showRotationButtonIfNoRotation = false;
   public hasFeatureEmphasisOnSelection: Boolean = false;
   public workspaceNotAvailableMessage: String = 'workspace.disabled.resolution';
@@ -317,8 +317,8 @@ export class PortalComponent implements OnInit, OnDestroy {
     this.hasExpansionPanel = this.configService.getConfig('hasExpansionPanel');
     this.hasGeolocateButton =
       this.configService.getConfig('hasGeolocateButton') === undefined ? true : this.configService.getConfig('hasGeolocateButton');
-    this.setHomeExtentButton =
-      this.configService.getConfig('setHomeExtentButton') === undefined ? true : this.configService.getConfig('setHomeExtentButton');
+    this.hasHomeExtentButton =
+      this.configService.getConfig('homeExtentButton') === undefined ? false : true;
     this.showRotationButtonIfNoRotation =
       this.configService.getConfig('showRotationButtonIfNoRotation') === undefined ?
         false :

--- a/src/app/pages/portal/portal.component.ts
+++ b/src/app/pages/portal/portal.component.ts
@@ -114,6 +114,7 @@ export class PortalComponent implements OnInit, OnDestroy {
   public minSearchTermLength = 2;
   public hasExpansionPanel = false;
   public hasGeolocateButton = true;
+  public setHomeExtentButton = true;
   public showRotationButtonIfNoRotation = false;
   public hasFeatureEmphasisOnSelection: Boolean = false;
   public workspaceNotAvailableMessage: String = 'workspace.disabled.resolution';
@@ -316,6 +317,8 @@ export class PortalComponent implements OnInit, OnDestroy {
     this.hasExpansionPanel = this.configService.getConfig('hasExpansionPanel');
     this.hasGeolocateButton =
       this.configService.getConfig('hasGeolocateButton') === undefined ? true : this.configService.getConfig('hasGeolocateButton');
+    this.setHomeExtentButton =
+      this.configService.getConfig('setHomeExtentButton') === undefined ? true : this.configService.getConfig('setHomeExtentButton');
     this.showRotationButtonIfNoRotation =
       this.configService.getConfig('showRotationButtonIfNoRotation') === undefined ?
         false :

--- a/src/config/config.json
+++ b/src/config/config.json
@@ -15,7 +15,7 @@
   "showRotationButtonIfNoRotation": false,
   "hasFeatureEmphasisOnSelection": true,
   "menuButtonReverseColor": false,
-  "setHomeExtentButton": {
+  "homeExtentButton": {
     "homeExtButtonExtent":[-9000000, 5790000,-7500000, 6770000],
     "homeExtButtonCenter": [-73.938087, 49.000000],
     "homeExtButtonZoom" : 6

--- a/src/config/config.json
+++ b/src/config/config.json
@@ -17,7 +17,7 @@
   "menuButtonReverseColor": false,
   "homeExtentButton": {
     "homeExtButtonExtent":[-9000000, 5790000,-7500000, 6770000],
-    "homeExtButtonCenter": [-73.938087, 49.000000],
+    "homeExtButtonCenter": [-71.938087, 48.446975],
     "homeExtButtonZoom" : 6
   },
   "searchSources": {

--- a/src/config/config.json
+++ b/src/config/config.json
@@ -15,6 +15,11 @@
   "showRotationButtonIfNoRotation": false,
   "hasFeatureEmphasisOnSelection": true,
   "menuButtonReverseColor": false,
+  "setHomeExtentButton": {
+    "homeExtButtonExtent":[-9000000, 5790000,-7500000, 6770000],
+    "homeExtButtonCenter": [-73.938087, 49.000000],
+    "homeExtButtonZoom" : 6
+  },
   "searchSources": {
     "cadastre": {
       "available": false

--- a/src/config/interactiveTour.json
+++ b/src/config/interactiveTour.json
@@ -148,12 +148,14 @@
       {
       "element": "igo-home-extent-button",
       "title": "interactiveTour.global.home-extent-title",
-      "text": "interactiveTour.global.home-extent-text"
+      "text": "interactiveTour.global.home-extent-text",
+      "noBackButton": true
       },
       {
         "element": "igo-geolocate-button",
         "title": "interactiveTour.global.geolocate-title",
-        "text": "interactiveTour.global.geolocate"
+        "text": "interactiveTour.global.geolocate",
+        "noBackButton": true
       },
       {
         "element": "igo-user-button",

--- a/src/config/interactiveTour.json
+++ b/src/config/interactiveTour.json
@@ -154,8 +154,7 @@
       {
         "element": "igo-geolocate-button",
         "title": "interactiveTour.global.geolocate-title",
-        "text": "interactiveTour.global.geolocate",
-        "noBackButton": true
+        "text": "interactiveTour.global.geolocate"
       },
       {
         "element": "igo-user-button",

--- a/src/config/interactiveTour.json
+++ b/src/config/interactiveTour.json
@@ -133,7 +133,7 @@
         }
       },
       {
-        "element": "#homeExtentButton",
+        "element": "#homeButton",
         "title": "interactiveTour.global.menu-button-title",
         "text": "interactiveTour.global.home-button",
         "disableInteraction": true,

--- a/src/config/interactiveTour.json
+++ b/src/config/interactiveTour.json
@@ -133,7 +133,7 @@
         }
       },
       {
-        "element": "#homeButton",
+        "element": "#homeExtentButton",
         "title": "interactiveTour.global.menu-button-title",
         "text": "interactiveTour.global.home-button",
         "disableInteraction": true,
@@ -146,10 +146,14 @@
         }
       },
       {
+      "element": "igo-home-extent-button",
+      "title": "interactiveTour.global.home-extent-title",
+      "text": "interactiveTour.global.home-extent-text"
+      },
+      {
         "element": "igo-geolocate-button",
         "title": "interactiveTour.global.geolocate-title",
-        "text": "interactiveTour.global.geolocate",
-        "noBackButton": true
+        "text": "interactiveTour.global.geolocate"
       },
       {
         "element": "igo-user-button",

--- a/src/contexts/_base.json
+++ b/src/contexts/_base.json
@@ -2,7 +2,7 @@
   "map": {
     "view": {
       "projection": "EPSG:3857",
-      "center": [-71.938087, 48.446975],
+      "center": [73.938087, 49.000000],
       "zoom": 6,
       "maxZoom": 19,
       "maxZoomOnExtent": 17

--- a/src/contexts/_base.json
+++ b/src/contexts/_base.json
@@ -2,7 +2,7 @@
   "map": {
     "view": {
       "projection": "EPSG:3857",
-      "center": [73.938087, 49.000000],
+      "center": [-73.938087, 49.000000],
       "zoom": 6,
       "maxZoom": 19,
       "maxZoomOnExtent": 17

--- a/src/contexts/_base.json
+++ b/src/contexts/_base.json
@@ -2,7 +2,7 @@
   "map": {
     "view": {
       "projection": "EPSG:3857",
-      "center": [-73.938087, 49.000000],
+      "center": [-71.938087, 48.446975],
       "zoom": 6,
       "maxZoom": 19,
       "maxZoomOnExtent": 17

--- a/src/contexts/_contexts.json
+++ b/src/contexts/_contexts.json
@@ -46,5 +46,9 @@
   {
     "uri": "legends",
     "title": "Exemples de légendes"
+  },
+  {
+    "uri": "homeExtent",
+    "title": "Étendue de la carte(Home Extent)"
   }
 ]

--- a/src/contexts/homeExtent.json
+++ b/src/contexts/homeExtent.json
@@ -1,0 +1,13 @@
+{
+  "uri": "homeExtent",
+  "base": "_base",
+  "map": {
+    "view": {
+      "projection": "EPSG:3857",
+      "homeExtent": {
+        "center": [-68.79600,51.32676],
+        "zoom": 10
+      }
+    }
+  }
+}

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -224,5 +224,9 @@
     "legend-tab": "Let's toggle legend tab.",
     "legend-tab-description": "This tab can be used to display all layer's legend. By default, only visible layers at active scale will have their legend displayed.",
     "legend-tab-all": "Allow to also display non visible layer's legend at active scale."
+  },
+  "messages": {
+    "title": "Title from a translation",
+    "message": "Message from a translation - <div class='toast-message-green-div'>Message at the context level </div>Open the layer 'MSP Tel. Urgence' to see messages at the layer level."
   }
 }

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -30,6 +30,9 @@
     "previousFeatureTooltip": "Previous feature ( shortcut = left arrow)",
     "nextFeatureTooltip": "Next feature ( shortcut = right arrow)"
   },
+  "home-extent": {
+    "tooltip": "Go back to initial position"
+  },
   "IGO": "IGO",
   "noEntityStore": "No tables available for this dataset",
   "coordinates": "Show coordinates",
@@ -44,9 +47,6 @@
   "oldBrowser": {
     "title": "Too old browser",
     "message": "IGO2 does not fully support your browser. Please update it or use a different one."
-  },
-  "home-extent": {
-    "tooltip": "Go back to initial position"
   },
   "interactiveTour": {
     "global": {
@@ -93,6 +93,8 @@
       "home-button": "This button allow to get back to main menu",
       "geolocate-title": "GEOLOCATE",
       "geolocate": "To zoom the map to your location.",
+      "home-extent-title": "HOME EXTENT",
+      "home-extent-text": "To go to the home map extent",
       "user-title": "USER",
       "user-button": "To authenticate you or to disconnect and stay anonymous.",
       "baselayers-title": "BASELAYERS",

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -45,6 +45,9 @@
     "title": "Too old browser",
     "message": "IGO2 does not fully support your browser. Please update it or use a different one."
   },
+  "home-extent": {
+    "tooltip": "Go back to initial position"
+  },
   "interactiveTour": {
     "global": {
       "title": "Interactive tour",

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -224,9 +224,5 @@
     "legend-tab": "Let's toggle legend tab.",
     "legend-tab-description": "This tab can be used to display all layer's legend. By default, only visible layers at active scale will have their legend displayed.",
     "legend-tab-all": "Allow to also display non visible layer's legend at active scale."
-  },
-  "messages": {
-    "title": "Title from a translation",
-    "message": "Message from a translation - <div class='toast-message-green-div'>Message at the context level </div>Open the layer 'MSP Tel. Urgence' to see messages at the layer level."
   }
 }

--- a/src/locale/fr.json
+++ b/src/locale/fr.json
@@ -30,6 +30,9 @@
     "previousFeatureTooltip": "Entité précédente ( raccouci clavier = flèche gauche )",
     "nextFeatureTooltip": "Prochaine entité ( raccouci clavier = flèche droite )"
   },
+  "home-extent": {
+    "tooltip": "Aller à l'étendue de la carte"
+  },
   "IGO": "IGO",
   "noEntityStore": "Aucune table disponible pour ce jeu de données",
   "coordinates": "Afficher les coordonnées",
@@ -44,9 +47,6 @@
   "oldBrowser": {
     "title": "Navigateur obsolète",
     "message": "IGO2 ne supporte pas pleinement votre navigateur. Veuillez le mettre à jour ou utilisez un navigateur différent."
-  },
-  "home-extent": {
-    "tooltip": "Aller à l'étendue de la carte"
   },
   "interactiveTour": {
     "global": {
@@ -91,6 +91,8 @@
       "tool-choose": "Si nous sélectionnons un outil de la boîte à outils...",
       "tool-enter": "...son contenu s'affichera ici.",
       "home-button": "Ce bouton nous permet ensuite le retour au menu principal.",
+      "home-extent-title": "ÉTENDUE DE LA CARTE",
+      "home-extent-text": "Pour revenir à l'étendue de la carte.",
       "geolocate-title": "GEOLOCALISATION",
       "geolocate": "Pour zoomer la carte sur votre position.",
       "user-title": "UTILISATEUR",

--- a/src/locale/fr.json
+++ b/src/locale/fr.json
@@ -223,5 +223,9 @@
       "legend-tab-description": "Cet onglet permet de visualiser rapidement l'ensemble des légendes. Par défaut, seules les légendes des couches visibles à l'échelle active sont présentées.",
       "legend-tab-all": "Permet de visualiser aussi l'ensemble des légendes des couches non visibles à l'échelle active."
     }
+  },
+  "messages": {
+    "title": "Titre provenant d'une traduction",
+    "message": "Message provenant d'une traduction - <div class='toast-message-green-div'>Message provenant du contexte</div>Ouvrez lea couche 'MSP Tel. Urgence' pour voir les messages liés."
   }
 }

--- a/src/locale/fr.json
+++ b/src/locale/fr.json
@@ -223,9 +223,5 @@
       "legend-tab-description": "Cet onglet permet de visualiser rapidement l'ensemble des légendes. Par défaut, seules les légendes des couches visibles à l'échelle active sont présentées.",
       "legend-tab-all": "Permet de visualiser aussi l'ensemble des légendes des couches non visibles à l'échelle active."
     }
-  },
-  "messages": {
-    "title": "Titre provenant d'une traduction",
-    "message": "Message provenant d'une traduction - <div class='toast-message-green-div'>Message provenant du contexte</div>Ouvrez lea couche 'MSP Tel. Urgence' pour voir les messages liés."
   }
 }

--- a/src/locale/fr.json
+++ b/src/locale/fr.json
@@ -45,6 +45,9 @@
     "title": "Navigateur obsolète",
     "message": "IGO2 ne supporte pas pleinement votre navigateur. Veuillez le mettre à jour ou utilisez un navigateur différent."
   },
+  "home-extent": {
+    "tooltip": "Aller à l'étendue de la carte"
+  },
   "interactiveTour": {
     "global": {
       "title": "Tour interatif",


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines:https://github.com/infra-geo-ouverte/igo2/blob/master/.github/CONTRIBUTING.md#git-commit-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What is the current behavior?** (You can also link to an open issue here)
The button to return to the home extent of the map is missing.


**What is the new behavior?**
The user can clic the button on the map to return to the home extent. The home extent can be defined (in config.json) for each portal and can be different from the initial extent. 


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications:


**Other information**:
![image](https://user-images.githubusercontent.com/90412486/153457576-b4b7fd4a-5582-4a40-bdb4-fd90ec8dba3e.png)
