### PR TITLE
feat(portal) Close query InfoPanel on context change

### DIFF
--- a/src/app/pages/portal/portal.component.ts
+++ b/src/app/pages/portal/portal.component.ts
@@ -678,6 +678,9 @@ export class PortalComponent implements OnInit, OnDestroy {
     if (context === undefined) {
       return;
     }
+    if (!this.queryState.store.empty) {
+      this.queryState.store.softClear();
+    }
 
     this.route.queryParams.pipe(debounceTime(250)).subscribe((qParams) => {
       if (!qParams['context'] || qParams['context'] === context.uri) {


### PR DESCRIPTION

**What is the current behavior?** (You can also link to an open issue here)
https://github.com/infra-geo-ouverte/igo2/issues/721


**What is the new behavior?**
the query infopanel close when the context change


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[ x] No
```

