### PR TITLE
fix(portal) Wks clear entityStore on context change

### DIFF
--- a/src/app/pages/portal/portal.component.ts
+++ b/src/app/pages/portal/portal.component.ts
@@ -750,6 +750,10 @@ export class PortalComponent implements OnInit, OnDestroy {
     if (context === undefined) {
       return;
     }
+    if (this.workspace && !this.workspace.entityStore.empty) {
+      this.workspace.entityStore.clear();
+    }
+    
     if (!this.queryState.store.empty) {
       this.queryState.store.softClear();
     }

--- a/src/app/pages/portal/portal.component.ts
+++ b/src/app/pages/portal/portal.component.ts
@@ -753,7 +753,6 @@ export class PortalComponent implements OnInit, OnDestroy {
     if (this.workspace && !this.workspace.entityStore.empty) {
       this.workspace.entityStore.clear();
     }
-    
     if (!this.queryState.store.empty) {
       this.queryState.store.softClear();
     }


### PR DESCRIPTION

**What is the current behavior?** (You can also link to an open issue here)
https://github.com/infra-geo-ouverte/igo2/issues/768


**What is the new behavior?**
The workspace.entityStore is now clear on context change


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x ] No
```
