### PR TITLE
feat(edition): add button is now configurable

### DIFF
--- a/docs/_tables/fr/properties/edition.csv
+++ b/docs/_tables/fr/properties/edition.csv
@@ -11,3 +11,6 @@ messages ,Object[] ,Personnaliser les messages affichés à l'utilisateur.
 addHeaders ,Object ,Personnaliser les headers de l'appel fait à l'ajout
 modifyProtocole ,String ,Personnaliser le protocole d'appel fait la modification ,,patch
 modifyHeaders ,Object ,Personnaliser les headers de l'appel fait à la modification
+addButton ,Boolean ,Activer ou non le bouton d'ajout sur la couche. ,true/false ,true
+modifyButton ,Boolean ,Activer ou non le bouton de modification sur la couche. ,true/false ,true
+deleteButton ,Boolean ,Activer ou non le bouton de suppression sur la couche. ,true/false ,true

--- a/src/app/pages/portal/portal.component.html
+++ b/src/app/pages/portal/portal.component.html
@@ -153,6 +153,7 @@
         collapsibleButton
         tooltip-position="below"
         matTooltipShowDelay="500"
+        [disabled]="workspace.layer.options.sourceOptions.edition.addButton === false ? true : false"
         [matTooltip]="('workspace.addFeature') | translate"
         (click)="addFeature(workspace)">
         <mat-icon


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines:https://github.com/infra-geo-ouverte/igo2/blob/master/.github/CONTRIBUTING.md#git-commit-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)


**What is the current behavior?** (You can also link to an open issue here)
add button is always available


**What is the new behavior?**
add button can now be disabled by default edition config


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[X] No

