### PR TITLE
fix: url with version on share map link

### DIFF
--- a/src/app/pages/portal/portal.component.ts
+++ b/src/app/pages/portal/portal.component.ts
@@ -1286,6 +1286,9 @@ export class PortalComponent implements OnInit, OnDestroy {
       if (version) {
         url = url.replace('VERSION=' + version, '').replace('version=' + version, '');
       }
+      if (url.endsWith('?')) {
+        url = url.substring(0, url.length - 1);
+      }
 
       const currentLayersByService = this.extractLayersByService(
         layersByService[cnt]


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines:https://github.com/infra-geo-ouverte/igo2/blob/master/.github/CONTRIBUTING.md#git-commit-guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What is the current behavior?** (You can also link to an open issue here)
On use of the map sharing tool a layer coming from a service with specific version does not retrieve the associated options via "OptionsApiService" when retrieving the link. The reason is that the recovery code does not remove the '?' character (add in the url to register the version) for to make the match with the "OptionsApiService" service and the match is not done.

- Exemple of WMS: https://servicesvectoriels.atlas.gouv.qc.ca/IDS_GIIN_SW_WMS//service.svc/get?versio=1.1.1
- Exemple IGO link with this wms: `...../?context=_default&zoom=6&center=-71.78933,51.3&invisiblelayers=*&visiblelayers=42ecd6eb-d971-d768-03b0-6d45b2283dc9,a2deb748-a408-66ee-5ce4-def679f5a0b6,5cac27cbded79ad3bac1701aaa6f0cca,fondTQ&wmsUrl=..../get%3FVERSION%3D1.1.1&wmsLayers=(PROJ_IAE_EN_COURS:igoz20)`


**What is the new behavior?**
Layer matching is now possible via the "OptionsApiService" service with a wms using a specific version other than the default one


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications:


**Other information**:
