### PR TITLE
refactor(layerSync): remove bidirectionnal property

### DIFF
--- a/docs/_tables/fr/properties/layersLinkProperties.csv
+++ b/docs/_tables/fr/properties/layersLinkProperties.csv
@@ -1,7 +1,4 @@
 Propriétés,Type,Description,Valeurs possibles,Valeur défaut
-bidirectionnal ,Boolean ,"| Indique si les 2 couches sont liées de manière
-| bi-directionnelles. C'est à dire, si une modification
-| de l'enfant est transférée au parent et inversement.",true | false,true
 **linkedIds** ,String[] ,"| Liste des identifiants de liaison.
 | C'est à dire, une liste des linkId des couches enfant. 
 ",,

--- a/docs/properties.rst
+++ b/docs/properties.rst
@@ -279,7 +279,6 @@ Exemples
             {"linkedLayers": {
                 "linkId": "wmsTimeFilterSrc",
                 "links": [{
-                            "bidirectionnal": true,
                             "linkedIds": ["wmsTimeFilterDest"],
                             "syncedDelete": true,
                             "properties": ["opacity","timeFilter","visible"]

--- a/src/contexts/_base.json
+++ b/src/contexts/_base.json
@@ -52,7 +52,6 @@
       "linkedLayers": {
         "linkId": "HybrideAuto",
         "links": [{
-          "bidirectionnal": true,
           "syncedDelete": true,
           "linkedIds": ["hybrideAutoRoute"],
           "properties": ["visible"]
@@ -91,7 +90,6 @@
       "linkedLayers": {
         "linkId": "HybrideVelo",
         "links": [{
-          "bidirectionnal": true,
           "syncedDelete": true,
           "linkedIds": ["hybrideVeloConviv"],
           "properties": ["visible"]

--- a/src/contexts/layerSync.json
+++ b/src/contexts/layerSync.json
@@ -30,7 +30,6 @@
         "linkedLayers": {
           "linkId": "wmsTimeFilterSrc",
           "links": [{
-            "bidirectionnal": true,
             "linkedIds": ["wmsTimeFilterDest"],
             "properties": ["opacity","timeFilter","visible"]
             }]
@@ -90,7 +89,6 @@
         "linkedLayers": {
           "linkId": "wmsOgcFiltersSrc",
           "links": [{
-            "bidirectionnal": true,
             "syncedDelete": true,
             "linkedIds": ["wmsOgcFiltersDest","wfsOgcFilterDest"],
             "properties": ["zIndex", "opacity","visible","ogcFilters","minResolution", "maxResolution" ]


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines:https://github.com/infra-geo-ouverte/igo2/blob/master/.github/CONTRIBUTING.md#git-commit-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What is the current behavior?** (You can also link to an open issue here)
Bidirectionnal property can be set to true or false when setting sync layers


**What is the new behavior?**
Bidirectionnal property has been removed as of now, every sync layer are bidirectionnal
https://github.com/infra-geo-ouverte/igo2-lib/pull/1107


**Does this PR introduce a breaking change?** (check one with "x")
```
[X] Yes
[ ] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications:
Remove bidirectionnal property from linked layers configuration

**Other information**:
