### PR TITLE
Coords format lat lon

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "e2e": "ng e2e --port 4300",
     "postinstall": "ngcc --tsconfig src/tsconfig.app.json && gulp copyLocaleFromLib",
     "build.prod": "ng build --configuration production",
-    "build.github": "npm build --configuration=github --output-path ./dist/ghpages --base-href /igo2/",
+    "build.github": "ng build --configuration=github --output-path ./dist/ghpages --base-href /igo2/",
     "build.pwa": "ng build --configuration pwa --output-path ./dist/pwa",
     "serve.prod": "http-server ./dist/igo2/ --port 4201 --no-browser",
     "serve.pwa": "http-server ./dist/pwa/ --port 4201 --no-browser",

--- a/src/app/pages/portal/portal.component.html
+++ b/src/app/pages/portal/portal.component.html
@@ -24,6 +24,8 @@
       (pointerSummaryStatus)="onPointerSummaryStatusChange($event)"
       [searchResultsGeometryEnabled]="searchResultsGeometryEnabled"
       (searchResultsGeometryStatus)="onSearchResultsGeometryStatusChange($event)"
+      [changeSearchCoordsFormatEnabled]="igoChangeSearchCoordsFormatEnabled"
+      (changeSearchCoordsFormatStatus)="onchangeCoordsFormatStatusChange($event)"
       (search)="onSearch($event)"
       (clearFeature)="onClearSearch()"
       (searchSettingsChange)="onSearchSettingsChange()">

--- a/src/app/pages/portal/portal.component.ts
+++ b/src/app/pages/portal/portal.component.ts
@@ -163,6 +163,7 @@ export class PortalComponent implements OnInit, OnDestroy {
   private sidenavMediaAndOrientation$$: Subscription;
 
   public igoSearchPointerSummaryEnabled: boolean;
+  public igoChangeSearchCoordsFormatEnabled: boolean;
 
   public toastPanelForExpansionOpened = true;
   private activeWidget$$: Subscription;
@@ -354,6 +355,8 @@ export class PortalComponent implements OnInit, OnDestroy {
     if (this.igoSearchPointerSummaryEnabled === undefined) {
       this.igoSearchPointerSummaryEnabled = this.storageService.get('searchPointerSummaryEnabled') as boolean || false;
     }
+
+    this.igoChangeSearchCoordsFormatEnabled = this.storageService.get('changeSearchCoordsFormatEnabled') as boolean || false;
   }
 
   ngOnInit() {
@@ -789,6 +792,11 @@ export class PortalComponent implements OnInit, OnDestroy {
     this.searchState.setSearchResultsGeometryStatus(value);
   }
 
+  onchangeCoordsFormatStatusChange(value) {
+    this.storageService.set('changeSearchCoordsFormatEnabled', value);
+    this.igoChangeSearchCoordsFormatEnabled = value;
+  }
+
   onSearchSettingsChange() {
     this.onSettingsChange$.next(true);
   }
@@ -946,7 +954,8 @@ export class PortalComponent implements OnInit, OnDestroy {
   }
 
   searchCoordinate(coord: [number, number]) {
-    this.searchBarTerm = coord.map((c) => c.toFixed(6)).join(', ');
+    this.searchBarTerm = (!this.igoChangeSearchCoordsFormatEnabled) ?
+    coord.map((c) => c.toFixed(6)).join(', ') : coord.reverse().map((c) => c.toFixed(6)).join(', ');
   }
 
   updateMapBrowserClass() {
@@ -1151,7 +1160,7 @@ export class PortalComponent implements OnInit, OnDestroy {
 
   private readLanguageParam(params) {
     if (params['lang']) {
-      this.authService.languageForce = true;
+      //this.authService.languageForce = true;
       this.languageService.setLanguage(params['lang']);
     }
   }


### PR DESCRIPTION
**What is the current behavior?** (You can also link to an open issue here)

this update relate to the issue #782 

**What is the new behavior?**

Add new option in search settings to Reverse coords format from 'lonLat' to 'latLon'
