### PR TITLE
feat(docs-config) Favorite context param and docs

### DIFF
--- a/docs/config_json.rst
+++ b/docs/config_json.rst
@@ -444,14 +444,23 @@ Liens
         - `igo2-lib/tree/master/packages/geo/src/lib/draw/draw <https://github.com/infra-geo-ouverte/igo2-lib/tree/master/packages/geo/src/lib/draw/draw>`_
 
 *****************
-favoriteContext4NonAuthenticated
+favoriteContext
 *****************
 
     .. line-block::
 
-        Permet d'afficher ou non le bouton de contexte favori (contextManager)
-        pour les utilisateurs non authentifiés. Le contexte favori sera enregistré
-        dans le "LocalStorage" du fureteur.
+        Permet d'afficher ou non le bouton de contexte favori (contextManager) pour les utilisateurs non authentifiés et de définir le style de bouton. 
+        Le contexte favori sera enregistré dans le "LocalStorage" du fureteur.
+
+Exemples
+
+        .. code:: json
+
+            "favoriteContext": {
+                "favoriteContext4NonAuthenticated": true,
+                "lightIcon": false
+            }
+
 
 *****************
 geolocate
@@ -466,10 +475,10 @@ Exemples
 
         .. code:: json
 
-            geolocate: {
-                "followPosition": "false",
-                "basic": "true",
-                "activateDefault": "false"
+            "geolocate": {
+                "followPosition": false,
+                "basic": true,
+                "activateDefault": false
             }
 
 *****************
@@ -500,7 +509,7 @@ hasGeolocateButton
 
     .. line-block::
 
-        Permet d'afficher ou non un bouton de géolocalisation dans l'application.
+        Permet d'afficher ou non un bouton de géolocalisation sur la carte dans l'application.
 
 ***********************
 hasSearchPointerSummary

--- a/docs/config_json.rst
+++ b/docs/config_json.rst
@@ -444,21 +444,23 @@ Liens
         - `igo2-lib/tree/master/packages/geo/src/lib/draw/draw <https://github.com/infra-geo-ouverte/igo2-lib/tree/master/packages/geo/src/lib/draw/draw>`_
 
 *****************
-favoriteContext
+contextConfig
 *****************
 
     .. line-block::
 
-        Permet d'afficher ou non le bouton de contexte favori (contextManager) pour les utilisateurs non authentifiés et de définir le style de bouton. 
-        Le contexte favori sera enregistré dans le "LocalStorage" du fureteur.
+        Permet de définir des configurations diverses sur les contexts. 
+        Ce sont des configurations générales autres que celles touchant l'outil contexte.
+        Lorsqu'un favori est définit pour les utilisateurs non authentifiés, le contexte favori sera enregistré dans le "LocalStorage" du fureteur.
 
 Exemples
 
         .. code:: json
-
-            "favoriteContext": {
-                "favoriteContext4NonAuthenticated": true,
-                "lightIcon": false
+            "contextConfig": {
+                "favoriteContext": {
+                    "favoriteContext4NonAuthenticated": true,
+                    "lightIcon": false
+                }
             }
 
 

--- a/src/config/config.json
+++ b/src/config/config.json
@@ -9,9 +9,12 @@
       "url": "/services/itineraire/route/v1/driving/"
     }
   },
-  "favoriteContext": {
-    "favoriteContext4NonAuthenticated": true,
-    "lightIcon": false
+
+  "contextConfig":{
+    "favoriteContext": {
+      "favoriteContext4NonAuthenticated": true,
+      "lightIcon": false
+    }
   },
 
   "theme": "blue-theme",

--- a/src/config/config.json
+++ b/src/config/config.json
@@ -9,7 +9,11 @@
       "url": "/services/itineraire/route/v1/driving/"
     }
   },
-  "favoriteContext4NonAuthenticated": true,
+  "favoriteContext": {
+    "favoriteContext4NonAuthenticated": true,
+    "lightIcon": false
+  },
+
   "theme": "blue-theme",
   "header": {
     "hasHeader": false,

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -22,7 +22,7 @@ interface Environment {
       forceCoordsNA: boolean;
     };
     auth?: AuthOptions;
-    storage: AuthStorageOptions
+    storage?: AuthStorageOptions
     catalog?: CatalogServiceOptions;
     context?: ContextServiceOptions;
     importExport?: ImportExportServiceOptions;


### PR DESCRIPTION
- add doc for new param
- config file add new param and new arrangement for favoriteContext param


**Does this PR introduce a breaking change?** (check one with "x")
```
[x ] Yes
[ ] No
```
The param in config file has been place in a contextConfig.favoriteContext object 

for nonAuth who use favorite, you have to change the place of the param in config file. 
If you don't, no problem on app, but you will lost the favorite button if there was true.
Else no problem

before in config.json :
 "favoriteContext4NonAuthenticated": true,

after in config.json:
      "contextConfig": {
          "favoriteContext": {
                "favoriteContext4NonAuthenticated": true,
                "lightIcon": false
            }
        }
