### PR TITLE
feat(toast): clear query result trigger workspace clear selection

### DIFF
--- a/src/app/pages/portal/toast-panel/toast-panel.component.ts
+++ b/src/app/pages/portal/toast-panel/toast-panel.component.ts
@@ -637,7 +637,7 @@ export class ToastPanelComponent implements OnInit, OnDestroy {
       const wksToHandle = workspaces.filter(wks => layersTitle.includes(wks.title));
       wksToHandle.map(ws => {
         ws.entityStore.state.updateMany(ws.entityStore.view.all(), { selected: false });
-      })
+      });
     }
   }
 

--- a/src/app/pages/portal/toast-panel/toast-panel.component.ts
+++ b/src/app/pages/portal/toast-panel/toast-panel.component.ts
@@ -45,7 +45,7 @@ import {
   StorageServiceEvent,
   ConfigService
 } from '@igo2/core';
-import { QueryState, StorageState } from '@igo2/integration';
+import { QueryState, StorageState, WorkspaceState } from '@igo2/integration';
 
 @Component({
   selector: 'app-toast-panel',
@@ -279,6 +279,7 @@ export class ToastPanelComponent implements OnInit, OnDestroy {
     public languageService: LanguageService,
     private storageState: StorageState,
     private queryState: QueryState,
+    private workspaceState: WorkspaceState,
     private configService: ConfigService
   ) {
     this.tabsMode = this.configService.getConfig('queryTabs')
@@ -605,7 +606,20 @@ export class ToastPanelComponent implements OnInit, OnDestroy {
     this.map.queryResultsOverlay.setFeatures(features, FeatureMotion.None, 'map');
   }
 
+  handleWksSelection() {
+    const entities = this.store.entities$.getValue();
+    const layersTitle = [...new Set(entities.map(e => e.source.title))];
+    const workspaces = this.workspaceState.store.entities$.getValue();
+    if (workspaces.length) {
+      const wksToHandle = workspaces.filter(wks => layersTitle.includes(wks.title));
+      wksToHandle.map(ws => {
+        ws.entityStore.state.updateMany(ws.entityStore.view.all(), { selected: false });
+      })
+    }
+  }
+
   clear() {
+    this.handleWksSelection();
     this.clearFeatureEmphasis();
     this.map.queryResultsOverlay.clear();
     this.store.clear();


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines:https://github.com/infra-geo-ouverte/igo2/blob/master/.github/CONTRIBUTING.md#git-commit-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What is the current behavior?** (You can also link to an open issue here)
When closing the toast panel (query result), the workspace selection was kept.


**What is the new behavior?**
Clear selection from workspaces


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications:


**Other information**:
