### PR TITLE
fix(InteractiveTour): replace deprecated position "auto" by "right"

### DIFF
--- a/docs/_tables/fr/interactiveTour/interactiveTourOptions.csv
+++ b/docs/_tables/fr/interactiveTour/interactiveTourOptions.csv
@@ -1,7 +1,7 @@
 Propriétés,Type,Description,Valeurs possibles,Valeur défaut
 disableInteraction ,Boolean ,Permet ou non à l'utilisateur de cliquer sur les éléments en surbrillance ,true | false ,true 
 highlightClass ,Boolean ,Définit la classe à appliquer aux éléments en surbrillance ,,
-position ,String ,Définit la position des boites aide ,"'auto', 'right', 'left', 'bottom', 'top'.","| NB.: Si la propriété position n'est pas présente, 
+position ,String ,Définit la position des boites aide ,"'top' | 'top-start' | 'top-end' | 'bottom' | 'bottom-start' | 'bottom-end' | 'right' | 'right-start' | 'right-end' | 'left' | 'left-start' | 'left-end'","| NB.: Si la propriété position n'est pas présente, 
 | les boites seront disposées au centre de l'écran."
 scrollToElement ,Boolean ,Indique si on défile la page sur l'élément en surbrillance ,true | false ,
 steps ,:ref:`InteractiveTourStep <igoInteractiveTourStep>` , Une liste de step (étapes du tour inteactif),,

--- a/docs/interactiveTour_config.rst
+++ b/docs/interactiveTour_config.rst
@@ -39,7 +39,7 @@ Exemples
 
         {
           "global": {
-            "position": "auto",
+            "position": "right",
             "scrollToElement":true,
             "title": "Titre de toutes les boites du tour",
             "steps": [
@@ -64,7 +64,7 @@ Propriétés - Objet InteractiveTourOptions
 
 
 Liens
-      - `TourOptions interface <https://github.com/infra-geo-ouverte/igo2-lib/tree/master/packages/common/src/lib/interactive-tour/interactive-tour.interface>`_
+      - `TourOptions interface <https://github.com/infra-geo-ouverte/igo2-lib/tree/master/packages/common/src/lib/interactive-tour/interactive-tour.interface.ts>`_
 
 
 Configurer les 'steps' des tours
@@ -120,7 +120,7 @@ Exemples
 
       {
         "global": {
-          "position": "auto",
+          "position": "right",
           "steps": [
             {
               "element": ".menu-button",

--- a/src/config/interactiveTour.json
+++ b/src/config/interactiveTour.json
@@ -1,7 +1,7 @@
 {
   "global": {
     "title": "interactiveTour.global.title",
-    "position": "auto",
+    "position": "right",
     "steps": [
       {
         "element": "#menu-button",


### PR DESCRIPTION
Regression in the interactive tour the placement was broken
https://github.com/infra-geo-ouverte/igo2-lib/issues/1398