### PR TITLE
fix(portal): search bar position when open/close sidenav

### DIFF
--- a/src/app/pages/portal/portal.component.html
+++ b/src/app/pages/portal/portal.component.html
@@ -3,7 +3,7 @@
     <igo-backdrop [shown]="backdropShown" (click)="onBackdropClick()">
     </igo-backdrop>
 
-    <div class="navbar-container" [class.navbar-fixed]="sidenavOpened">
+    <div class="navbar-container">
       <igo-menu-button
         *ngIf="showMenuButton"
         [class.mat-elevation-z2]="!sidenavOpened"

--- a/src/app/pages/portal/portal.component.scss
+++ b/src/app/pages/portal/portal.component.scss
@@ -16,13 +16,6 @@
     max-width: $search-bar-width;
     z-index: 4;
 
-    &.navbar-fixed {
-      left: 0;
-      top: 0;
-      height: $app-sidenav-margin-top;
-      align-items: center;
-    }
-
     @include mobile {
       width: $search-bar-width-mobile;
       max-width: min($search-bar-width-mobile, 350px);

--- a/src/app/pages/portal/portal.variables.scss
+++ b/src/app/pages/portal/portal.variables.scss
@@ -43,7 +43,7 @@ $app-sidenav-width-mobile: calc(
 );
 
 $search-bar-left: $igo-icon-size + $igo-margin;
-$search-bar-width: $app-sidenav-width;
+$search-bar-width: calc($app-sidenav-width - $igo-margin);
 $search-bar-width-mobile: calc(
   100% - #{$app-mobile-min-space-right} - (2 * #{$igo-margin})
 );


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines:https://github.com/infra-geo-ouverte/igo2/blob/master/.github/CONTRIBUTING.md#git-commit-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What is the current behavior?** (You can also link to an open issue here)
Due to 16.0.0 changes, the search bar is "jumping" when opening/close the side nav (from menu button)


**What is the new behavior?**
Impose the position (width) of the searchbar based on portal variables minus 5px.


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications:


**Other information**:
