### PR TITLE
add open in openstreetmap link to contextual menu on map

### DIFF
--- a/src/app/pages/portal/portal.component.ts
+++ b/src/app/pages/portal/portal.component.ts
@@ -49,6 +49,7 @@ import {
   FeatureMotion,
   FeatureWorkspace,
   GoogleLinks,
+  OsmLinks,
   IgoMap,
   ImageLayer,
   ImportService,
@@ -375,6 +376,11 @@ export class PortalComponent implements OnInit, OnDestroy {
         id: 'coordinates',
         title: 'coordinates',
         handler: () => this.searchCoordinate(this.contextMenuCoord)
+      },
+      {
+        id: 'openStreetMap',
+        title: 'openStreetMap',
+        handler: () => this.openOpenStreetMap(this.contextMenuCoord)
       },
       {
         id: 'googleMaps',
@@ -918,6 +924,10 @@ export class PortalComponent implements OnInit, OnDestroy {
     const coord = this.map.ol.getCoordinateFromPixel(pixel);
     const proj = this.map.projection;
     return olProj.transform(coord, proj, 'EPSG:4326');
+  }
+
+  private openOpenStreetMap(coord: [number, number]) {
+    window.open(OsmLinks.getOpenStreetMapLink(coord[0], coord[1], 14));
   }
 
   private openGoogleMaps(coord: [number, number]) {

--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -56,6 +56,7 @@
   "coordinates": "Show coordinates",
   "googleMap": "Show in Google Maps",
   "googleStreetView": "Show in Google Street View",
+  "openStreetMap": "Show in OpenStreetMap",
   "welcomeWindow": {
     "html": "<h1>Welcome to {{title}}, the Québec government mapping application </h1><h2>Version {{version}}, build on {{releaseDate}}</h2>",
     "title": "Home window",

--- a/src/locale/fr.json
+++ b/src/locale/fr.json
@@ -46,7 +46,11 @@
     "previousFeatureTooltip": "Entité précédente ( raccouci clavier = flèche gauche )",
     "nextFeatureTooltip": "Prochaine entité ( raccouci clavier = flèche droite )",
     "addLayer": "Ajouter la couche de donnée associée.",
-    "removeLayer": "Supprimer la couche de donnée associée de la carte."
+    "removeLayer": "Supprimer la couche de donnée associée de la carte.",
+    "coordinates": "Montrer les coordonnées",
+    "googleMap": "Ouvrir dans Google Maps",
+    "googleStreetView": "Ouvrir dans Google Street View",
+    "openStreetMap": "Ouvrir dans OpenStreetMap"
   },
   "home-extent": {
     "tooltip": "Aller à l'étendue de la carte"


### PR DESCRIPTION

- [x] The commit message follows our guidelines:https://github.com/infra-geo-ouverte/igo2/blob/master/.github/CONTRIBUTING.md#git-commit-guidelines
- [] Tests for the changes have been added (for bug fixes / features) -> there are no tests for this contextual menu.
- [] Docs have been added / updated (for bug fixes / features) -> there is no doc for this contextual menu.

**What is the current behavior?** (You can also link to an open issue here)

We can't open in openstreetmap using the map contextual menu

**What is the new behavior?**

Now we can use a link to OpenStreetMap using the contextual menu

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```