### PR TITLE
fix(app): this rule is not used anymore except in form-field-text.com…

### DIFF
--- a/src/app/app.component.scss
+++ b/src/app/app.component.scss
@@ -47,10 +47,3 @@ $footer-height: 29px;
     height: calc(100% - #{$header-height} - #{$footer-height}) !important;
   }
 }
-
-::ng-deep .mat-mdc-form-field-icon-suffix {
-  ::ng-deep mat-icon {
-    width: auto !important;
-    height: -webkit-fill-available !important;
-  }
-}


### PR DESCRIPTION
…ponent, resulting in extra large icon

**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines:https://github.com/infra-geo-ouverte/igo2/blob/master/.github/CONTRIBUTING.md#git-commit-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What is the current behavior?** (You can also link to an open issue here)
THis rule generate EXTRA LARGE icons
The only component with mat-form-field-icon-suffix is the form-field-text.component.
Here the effect of this rule.
![image](https://github.com/infra-geo-ouverte/igo2/assets/7397743/70cc4125-fa48-43c5-b286-da1a208bf2d2)



**What is the new behavior?**
Remove the rule.

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications:


**Other information**:
