### PR TITLE
feat(directions): added possibility to toggle between two routing sources

### DIFF
--- a/src/config/config.json
+++ b/src/config/config.json
@@ -1,7 +1,20 @@
 {
   "directionsSources": {
     "osrm": {
-      "url": "/services/itineraire/route/v1/driving/"
+      "name": "OSRM Québec",
+      "baseUrl": "/apis/itineraire/route/v1/",
+      "profiles": [
+        {
+          "name": "driving"
+        },
+        {
+          "name": "forestier",
+          "authorization": {
+            "url": "/apis/igo2/user/igo",
+            "property": "hasOsrmPrivateAccess"
+          }
+        }
+      ]
     }
   },
   "favoriteContext4NonAuthenticated": true,


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines:https://github.com/infra-geo-ouverte/igo2/blob/master/.github/CONTRIBUTING.md#git-commit-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What is the current behavior?** (You can also link to an open issue here)
At the moment, only one routing source can be used in the Directions tool.


**What is the new behavior?**
Two sources can now be used. In order to see the toggle to switch between the two, you need:

To be authenticated and authorized to use the second routing source.
Two routing sources that must be provided in the configs.
When the user activates the second/private source a message warns the user.


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications:


**Other information**:
See https://github.com/infra-geo-ouverte/igo2-lib/pull/1644