### PR TITLE
fix(sidenav): refactor tool imports and prevent tree-shaking with exp…

### DIFF
--- a/src/app/pages/portal/sidenav/sidenav-import.ts
+++ b/src/app/pages/portal/sidenav/sidenav-import.ts
@@ -1,0 +1,70 @@
+/**
+ * Ce fichier TEMPORAIRE permet de corriger un problème de tree-shaking
+ * https://github.com/infra-geo-ouverte/igo2/issues/1178
+ */
+import { ToolComponent } from '@igo2/common/tool';
+import {
+  AboutToolComponent,
+  ActiveOgcFilterToolComponent,
+  ActiveTimeFilterToolComponent,
+  AdvancedMapToolComponent,
+  CatalogBrowserToolComponent,
+  CatalogLibraryToolComponent,
+  ContextEditorToolComponent,
+  ContextManagerToolComponent,
+  ContextPermissionManagerToolComponent,
+  ContextShareToolComponent,
+  DataIssueReporterToolComponent,
+  DirectionsToolComponent,
+  DrawingToolComponent,
+  ImportExportToolComponent,
+  MapDetailsToolComponent,
+  MapLegendToolComponent,
+  MapProximityToolComponent,
+  MapToolComponent,
+  MapToolsComponent,
+  MeasurerToolComponent,
+  OgcFilterToolComponent,
+  PrintToolComponent,
+  SearchResultsToolComponent,
+  SpatialFilterToolComponent,
+  TimeFilterToolComponent
+} from '@igo2/integration';
+
+// Prevent Tree-Shaking with Explicit Imports
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const _TOOLS = [
+  ToolComponent,
+  AboutToolComponent,
+  CatalogBrowserToolComponent,
+  CatalogLibraryToolComponent,
+  ContextEditorToolComponent,
+  ContextManagerToolComponent,
+  ContextPermissionManagerToolComponent,
+  ContextShareToolComponent,
+  DirectionsToolComponent,
+  DrawingToolComponent,
+  ActiveOgcFilterToolComponent,
+  ActiveTimeFilterToolComponent,
+  OgcFilterToolComponent,
+  SpatialFilterToolComponent,
+  TimeFilterToolComponent,
+  DataIssueReporterToolComponent,
+  ImportExportToolComponent,
+  AdvancedMapToolComponent,
+  MapDetailsToolComponent,
+  MapLegendToolComponent,
+  MapProximityToolComponent,
+  MapToolComponent,
+  MapToolsComponent,
+  MeasurerToolComponent,
+  PrintToolComponent,
+  SearchResultsToolComponent
+];
+
+export function importAllTools() {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  for (const tool of _TOOLS) {
+    // @WORKAROUND Empty iteration to prevent tree shaking
+  }
+}

--- a/src/app/pages/portal/sidenav/sidenav.component.ts
+++ b/src/app/pages/portal/sidenav/sidenav.component.ts
@@ -16,13 +16,21 @@ import { MatTooltipModule } from '@angular/material/tooltip';
 import { HomeButtonComponent } from '@igo2/common/home-button';
 import { IgoInteractiveTourModule } from '@igo2/common/interactive-tour';
 import { PanelComponent } from '@igo2/common/panel';
-import { Tool, Toolbox, ToolboxComponent } from '@igo2/common/tool';
+import {
+  IgoToolModule,
+  IgoToolboxModule,
+  Tool,
+  Toolbox,
+  ToolboxComponent
+} from '@igo2/common/tool';
 import { ConfigService } from '@igo2/core/config';
 import { IgoMap, isLayerItem } from '@igo2/geo';
 import { CatalogState, ToolState } from '@igo2/integration';
 
 import { TranslateModule } from '@ngx-translate/core';
 import { BehaviorSubject, Subscription } from 'rxjs';
+
+import { importAllTools } from './sidenav-import';
 
 @Component({
   selector: 'app-sidenav',
@@ -41,7 +49,9 @@ import { BehaviorSubject, Subscription } from 'rxjs';
     NgIf,
     PanelComponent,
     ToolboxComponent,
-    TranslateModule
+    TranslateModule,
+    IgoToolModule,
+    IgoToolboxModule
   ]
 })
 export class SidenavComponent implements OnInit, OnDestroy {
@@ -83,7 +93,9 @@ export class SidenavComponent implements OnInit, OnDestroy {
     private toolState: ToolState,
     private configService: ConfigService,
     private catalogState: CatalogState
-  ) {}
+  ) {
+    importAllTools();
+  }
 
   ngOnInit() {
     this.activeTool$$ = this.toolbox.activeTool$.subscribe((tool: Tool) => {


### PR DESCRIPTION
C'est un fix temporaire pour faire fonctionner le sidenav.

Le ToolComponent va devoir être réécrit car il n'est pas fonctionnel avec les algorithmes de Tree Shaking d'Angular. Les composantes doivent être référencé pour être inclus dans les bundle applicatif.

Pour reproduire le bogue, à partir de la branche next:
- lancer un `npm run build.prod`
- lancer un `npm run serve.prod` 

Vous devriez avoir un menu de gauche sans outils, complètement blanc